### PR TITLE
Support Quantization Aware Training for QLinear

### DIFF
--- a/quanto/quantization/calibrate.py
+++ b/quanto/quantization/calibrate.py
@@ -20,16 +20,8 @@ def calibrate_input(module: torch.nn.Module, input):
         input_scale = scale_max(input, torch.int8)
         if torch.all(module.in_scale == 1):
             module.in_scale = input_scale
-            if module.bias is not None:
-                bias_scale = module.in_scale * module.weight._scale
-                # Quantize bias
-                module.bias = torch.nn.Parameter(QuantizedTensor.quantize(module.bias, torch.int32, bias_scale))
         else:
             module.in_scale = momentum * module.in_scale + input_scale * (1.0 - momentum)
-            if module.bias is not None:
-                bias_scale = module.in_scale * module.weight._scale
-                # (Re)quantize bias with the updated scale
-                module.bias = module.bias.rescale(torch.int32, bias_scale)
         return input
 
 

--- a/quanto/quantization/tensor.py
+++ b/quanto/quantization/tensor.py
@@ -117,6 +117,8 @@ def q_is_same_size(func, input, other):
 
 
 def q_mm(func, input, other):
+    if not isinstance(input, QuantizedTensor) or not isinstance(other, QuantizedTensor):
+        return func(input.dequantize(), other.dequantize())
     # Cast int8 data to float32 and do the operation
     out_data = func(input._data.to(torch.float32), other._data.to(torch.float32))
     out_scale = input._scale * other._scale


### PR DESCRIPTION
This modifies the QLinear quantized module to:

- quantize weights and biases during inference by default,
- add a freeze() method that replaces float weights and biases by quantized weights and biases.

The freeze() method must be called before serialization.