### PR TITLE
docs: explicitly reference optimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
-# Quanto
+# Optimum Quanto
 
-**IMPORTANT**:
-
-After having gathered feedback from our partners and the community, we have decided that `quanto` would not continue as a standalone project but would rather be merged into the [optimum](https://huggingface.co/docs/optimum/en/index) project.
-External contributions to quanto will be suspended until the merge is complete.
-
-**DISCLAIMER**: This package is still beta. Expect breaking changes in API and serialization.
-
-🤗 Quanto is a python quantization toolkit that provides several features that are either not supported or limited by the base [pytorch quantization tools](https://pytorch.org/docs/stable/quantization.html):
+🤗 Optimum Quanto is a python quantization backend for [optimum](https://huggingface.co/docs/optimum/en/index) that provides several features that are either not supported or limited by the base [pytorch quantization tools](https://pytorch.org/docs/stable/quantization.html):
 
 - all features are available in eager mode (works with non-traceable models),
 - quantized models can be placed on any device (including CUDA and MPS),


### PR DESCRIPTION
# What does this PR do?

As a first step in the migration to [optimum](https://huggingface.co/docs/optimum/en/index), the repository has been renamed and the README updated.