### PR TITLE
Only use optimized CUDA kernels if arch is at least sm80

### DIFF
--- a/optimum/quanto/__init__.py
+++ b/optimum/quanto/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.1dev"
+__version__ = "0.2.2dev"
 
 from .calibrate import *
 from .library import *

--- a/optimum/quanto/library/ext/cuda/awq/v2/gemm_cuda.cu
+++ b/optimum/quanto/library/ext/cuda/awq/v2/gemm_cuda.cu
@@ -5,6 +5,9 @@
 #include <torch/extension.h>
 #include <cuda_pipeline_primitives.h>
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+// The following GEMMs requires m16n8k16 which is only supported for CUDA arch after sm80
+
 #define kInterleave 4
 #define OP_M 16
 #define OP_N 8
@@ -1023,3 +1026,16 @@ torch::Tensor awq_v2_gemm_f16i4(
 
   return _out_feats;
 }
+
+#else // if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+
+torch::Tensor awq_v2_gemm_f16i4(
+    torch::Tensor _in_feats,
+    torch::Tensor _kernel,
+    torch::Tensor _scales,
+    torch::Tensor _zeros)
+{
+  throw std::runtime_error("This GEMM requires a CUDA arch >= sm80.\n");
+}
+
+#endif // if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800

--- a/optimum/quanto/tensor/qbits/qbits.py
+++ b/optimum/quanto/tensor/qbits/qbits.py
@@ -83,6 +83,7 @@ class QBitsTensor(QTensor):
             and group_size == 128
             and len(size) == 2
             and data.device.type == "cuda"
+            and torch.cuda.get_device_capability(data.device)[0] >= 8
         ):
             if type(data) == PackedTensor:
                 data = data.unpack()

--- a/test/library/test_mm.py
+++ b/test/library/test_mm.py
@@ -31,7 +31,10 @@ def test_dqmm(input_shape, output_features, dtype, device):
     assert torch.equal(expected, output)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 8,
+    reason="CUDA device >= sm80 not available",
+)
 @pytest.mark.parametrize("in_features, out_features", [(256, 256), (512, 256)])
 @pytest.mark.parametrize("batch_size, tokens", [(4, 1), (10, 128)], ids=["gemv", "gemm"])
 def test_gemm_fp16_int4(batch_size, tokens, in_features, out_features):


### PR DESCRIPTION
# What does this PR do?

This modifies:

- the compilation of the library to include optimized kernels only if CUDA arch >= sm80,
- the QBitsTensor class to create optimized Tensors for these kernels only if CUDA arch >= sm80.

Fixes #207