### PR TITLE
Extension lifecycle

### DIFF
--- a/optimum/quanto/library/ext/cpp/__init__.py
+++ b/optimum/quanto/library/ext/cpp/__init__.py
@@ -15,31 +15,21 @@
 import os
 
 import torch
-from torch.utils.cpp_extension import load
+
+from ..extension import Extension
 
 
 __all__ = []
 
 
-_ext = None
-
-
-def ext():
-    """Helper to load the CPU ext only when it is required"""
-    global _ext
-    if _ext is None:
-        module_path = os.path.dirname(__file__)
-        _ext = load(
-            name="quanto_cpp",
-            sources=[
-                f"{module_path}/unpack.cpp",
-                f"{module_path}/pybind_module.cpp",
-            ],
-            extra_cflags=["-O3"],
-        )
-    return _ext
+ext = Extension(
+    "quanto_cpp",
+    root_dir=os.path.dirname(__file__),
+    sources=["unpack.cpp", "pybind_module.cpp"],
+    extra_cflags=["-O3"],
+)
 
 
 @torch.library.impl("quanto_ext::unpack", ["CPU"])
 def unpack_cpp(t: torch.Tensor, bits: int):
-    return ext().unpack(t, bits)
+    return ext.lib.unpack(t, bits)

--- a/optimum/quanto/library/ext/extension.py
+++ b/optimum/quanto/library/ext/extension.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import warnings
 from typing import List
 
 import torch
@@ -34,6 +35,9 @@ class Extension(object):
                     pytorch_build_version = f.read().rstrip()
                     if pytorch_build_version != torch.__version__:
                         shutil.rmtree(self.build_directory)
+                        warnings.warn(
+                            f"{self.name} was compiled with pytorch {pytorch_build_version}, but {torch.__version__} is installed: it will be recompiled."
+                        )
             os.makedirs(self.build_directory, exist_ok=True)
             self._lib = load(
                 name=self.name,

--- a/optimum/quanto/library/ext/extension.py
+++ b/optimum/quanto/library/ext/extension.py
@@ -1,6 +1,8 @@
 import os
+import shutil
 from typing import List
 
+import torch
 from torch.utils.cpp_extension import load
 
 
@@ -25,6 +27,13 @@ class Extension(object):
     def lib(self):
         if self._lib is None:
             # We only load the extension when the lib is required
+            version_file = os.path.join(self.build_directory, "pytorch_version.txt")
+            if os.path.exists(version_file):
+                # The extension has already been built: check the torch version for which it was built
+                with open(version_file, "r") as f:
+                    pytorch_build_version = f.read().rstrip()
+                    if pytorch_build_version != torch.__version__:
+                        shutil.rmtree(self.build_directory)
             os.makedirs(self.build_directory, exist_ok=True)
             self._lib = load(
                 name=self.name,
@@ -33,4 +42,7 @@ class Extension(object):
                 extra_cuda_cflags=self.extra_cuda_cflags,
                 build_directory=self.build_directory,
             )
+            if not os.path.exists(version_file):
+                with open(version_file, "w") as f:
+                    f.write(torch.__version__)
         return self._lib

--- a/optimum/quanto/library/ext/extension.py
+++ b/optimum/quanto/library/ext/extension.py
@@ -1,0 +1,32 @@
+from typing import List
+
+from torch.utils.cpp_extension import load
+
+
+class Extension(object):
+
+    def __init__(
+        self,
+        name: str,
+        root_dir: str,
+        sources: List[str],
+        extra_cflags: List[str] = None,
+        extra_cuda_cflags: List[str] = None,
+    ):
+        self.name = name
+        self.sources = [f"{root_dir}/{source}" for source in sources]
+        self.extra_cflags = extra_cflags
+        self.extra_cuda_cflags = extra_cuda_cflags
+        self._lib = None
+
+    @property
+    def lib(self):
+        if self._lib is None:
+            # We only load the extension when the lib is required
+            self._lib = load(
+                name=self.name,
+                sources=self.sources,
+                extra_cflags=self.extra_cflags,
+                extra_cuda_cflags=self.extra_cuda_cflags,
+            )
+        return self._lib

--- a/optimum/quanto/library/ext/extension.py
+++ b/optimum/quanto/library/ext/extension.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 
 from torch.utils.cpp_extension import load
@@ -17,16 +18,19 @@ class Extension(object):
         self.sources = [f"{root_dir}/{source}" for source in sources]
         self.extra_cflags = extra_cflags
         self.extra_cuda_cflags = extra_cuda_cflags
+        self.build_directory = os.path.join(root_dir, "build")
         self._lib = None
 
     @property
     def lib(self):
         if self._lib is None:
             # We only load the extension when the lib is required
+            os.makedirs(self.build_directory, exist_ok=True)
             self._lib = load(
                 name=self.name,
                 sources=self.sources,
                 extra_cflags=self.extra_cflags,
                 extra_cuda_cflags=self.extra_cuda_cflags,
+                build_directory=self.build_directory,
             )
         return self._lib

--- a/optimum/quanto/library/ext/mps/__init__.py
+++ b/optimum/quanto/library/ext/mps/__init__.py
@@ -15,29 +15,21 @@
 import os
 
 import torch
-from torch.library import impl
-from torch.utils.cpp_extension import load
+
+from ..extension import Extension
 
 
 __all__ = []
 
 
-_ext = None
+ext = Extension(
+    "quanto_mps",
+    root_dir=os.path.dirname(__file__),
+    sources=["unpack.mm", "pybind_module.cpp"],
+    extra_cflags=["-std=c++17"],
+)
 
 
-def ext():
-    """Helper to load the MPS extension only when it is required"""
-    global _ext
-    if _ext is None:
-        module_path = os.path.dirname(__file__)
-        _ext = load(
-            name="quanto_mps",
-            sources=[f"{module_path}/unpack.mm", f"{module_path}/pybind_module.cpp"],
-            extra_cflags=["-std=c++17"],
-        )
-    return _ext
-
-
-@impl("quanto_ext::unpack", "MPS")
+@torch.library.impl("quanto_ext::unpack", "MPS")
 def unpack_mps(t: torch.Tensor, bits: int):
-    return ext().unpack(t, bits)
+    return ext.lib.unpack(t, bits)


### PR DESCRIPTION
# What does this PR do?

This first modifies the location of the cached built extensions to store them under the package directory.

This change will allow to fix broken installations by simply uninstalling and reinstalling the package.

This also modifies the extension build process to store the torch version when the extension was built: it is then checked when loading the extension and if it does not correspond to the current torch version the extension is rebuilt.

This will fix #194 