### PR TITLE
Readme code example should include save_pretrained [#136]

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ When freezing a model, its float weights are replaced by quantized integer weigh
 
 ```python
 freeze(model)
+# saving weights after quantization is applied
+model.save_pretrained(model_path)
 ```
 
 Please refer to the [examples](https://github.com/huggingface/quanto/tree/main/examples) for instantiations of that workflow.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ When freezing a model, its float weights are replaced by quantized integer weigh
 
 ```python
 freeze(model)
-# saving weights after quantization is applied
-model.save_pretrained(model_path)
+# save weights after quantization is applied
+safe_save(model.state_dict(), model_state_dict_path)
+model.save_pretrained(model_path) # for transformer models only
 ```
 
 Please refer to the [examples](https://github.com/huggingface/quanto/tree/main/examples) for instantiations of that workflow.


### PR DESCRIPTION
# What does this PR do?

As raised in #136, a common use-case is to save quantized weights of a model, and steps to do this correctly are not described in the README or examples. In the issue, I suggested adding a line of code here.
Currently the only `save_pretrained` in the repo is in an example which doesn't use this library, adding to possible confusion.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/optimum-quanto/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you run all tests locally and make sure they pass.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
