### PR TITLE
Add serialization in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,23 @@ When freezing a model, its float weights are replaced by quantized integer weigh
 freeze(model)
 ```
 
+**5. Serialize model**
+
+Quantized models can be serialized to a `state_dict`, and saved to a file.
+Both `pickle` and `safetensors` (recommended) are supported.
+
+```python
+safe_save(model.state_dict(), 'qmodel.safetensors')
+```
+
+**6. Reload quantized model**
+
+A serialized quantized model can be reloaded from a `state_dict` using the `requantize` helper. Note that you need first to instantiate an empty model.
+
+```python
+requantize(model, safe_load('qmodel.safetensors'))
+```
+
 Please refer to the [examples](https://github.com/huggingface/quanto/tree/main/examples) for instantiations of that workflow.
 
 ## Per-axis versus per-tensor

--- a/optimum/quanto/__init__.py
+++ b/optimum/quanto/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.2dev"
+__version__ = "0.2.3dev"
 
 from .calibrate import *
 from .library import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ homepage = 'https://github.com/huggingface/optimum-quanto'
 
 [project.optional-dependencies]
 dev = ['pytest', 'ruff', 'black']
-examples = ['torchvision', 'transformers==4.40.2', 'datasets', 'accelerate', 'scipy']
+examples = ['torchvision', 'transformers', 'datasets', 'accelerate', 'scipy']
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
# What does this PR do?

This adds two paragraphs to explain quantized models serialization in README.

This also modifies the MNIST example to use `safe_save`, `safe_load` and `requantize`.

This addresses #136 