### PR TITLE
Integrate quanto commands to optimum-cli

### DIFF
--- a/.github/workflows/linux-cpu-tests.yml
+++ b/.github/workflows/linux-cpu-tests.yml
@@ -42,9 +42,14 @@ jobs:
 
       - name: Run base tests
         run: |
-          python -m pytest test --ignore=test/models
+          python -m pytest test --ignore=test/models --ignore=test/cli
 
       - name: Run models tests
         run: |
           pip install accelerate transformers
           python -m pytest test/models
+
+      - name: Run CLI tests
+        run: |
+          pip install optimum
+          python -m pytest test/cli

--- a/.github/workflows/linux-cuda-tests.yml
+++ b/.github/workflows/linux-cuda-tests.yml
@@ -43,9 +43,14 @@ jobs:
 
       - name: Run base tests
         run: |
-          python -m pytest test --ignore=test/models
+          python -m pytest test --ignore=test/models --ignore=test/cli
 
       - name: Run models tests
         run: |
           pip install accelerate transformers
           python -m pytest test/models
+
+      - name: Run CLI tests
+        run: |
+          pip install optimum
+          python -m pytest test/cli

--- a/optimum/quanto/models/__init__.py
+++ b/optimum/quanto/models/__init__.py
@@ -20,4 +20,4 @@ def is_transformers_available() -> bool:
 
 
 if is_transformers_available():
-    from .causal_lm import *
+    from .transformers_models import *

--- a/optimum/quanto/subpackage/__init__.py
+++ b/optimum/quanto/subpackage/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .commands import *

--- a/optimum/quanto/subpackage/commands/__init__.py
+++ b/optimum/quanto/subpackage/commands/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base import *

--- a/optimum/quanto/subpackage/commands/base.py
+++ b/optimum/quanto/subpackage/commands/base.py
@@ -1,0 +1,34 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from optimum.commands import BaseOptimumCLICommand, CommandInfo
+from optimum.commands.optimum_cli import optimum_cli_subcommand
+
+from .quantize import QuantizeCommand
+
+
+__all__ = ["QuantoCommand"]
+
+
+@optimum_cli_subcommand()
+class QuantoCommand(BaseOptimumCLICommand):
+
+    COMMAND = CommandInfo(name="quanto", help="Hugging Face models quantization tools")
+    SUBCOMMANDS = (
+        CommandInfo(
+            name="quantize",
+            help="Quantize Hugging Face models.",
+            subcommand_class=QuantizeCommand,
+        ),
+    )

--- a/optimum/quanto/subpackage/commands/quantize.py
+++ b/optimum/quanto/subpackage/commands/quantize.py
@@ -1,0 +1,129 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Hugging Face models quantization command-line interface class."""
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from optimum.commands import BaseOptimumCLICommand
+from optimum.exporters import TasksManager
+
+from ...models import QuantizedTransformersModel
+
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+SUPPORTED_LIBRARIES = ["transformers"]
+
+
+def parse_quantize_args(parser: "ArgumentParser"):
+    required_group = parser.add_argument_group("Required arguments")
+    required_group.add_argument(
+        "output",
+        type=str,
+        help="The path to save the quantized model.",
+    )
+    required_group.add_argument(
+        "-m",
+        "--model",
+        type=str,
+        required=True,
+        help="Hugging Face Hub model id or path to a local model.",
+    )
+    required_group.add_argument(
+        "--weights",
+        type=str,
+        default="int8",
+        choices=["int2", "int4", "int8", "float8"],
+        help="The Hugging Face library to use to load the model.",
+    )
+
+    optional_group = parser.add_argument_group("Optional arguments")
+    optional_group.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="The Hugging Face model revision.",
+    )
+    optional_group.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        default=False,
+        help="Trust remote code when loading the model.",
+    )
+    optional_group.add_argument(
+        "--library",
+        type=str,
+        default=None,
+        choices=SUPPORTED_LIBRARIES,
+        help="The Hugging Face library to use to load the model.",
+    )
+    optional_group.add_argument(
+        "--task",
+        type=str,
+        default=None,
+        help="The model task (useful for models supporting multiple tasks).",
+    )
+    optional_group.add_argument(
+        "--torch_dtype",
+        type=str,
+        default="auto",
+        choices=["auto", "fp16", "bf16"],
+        help="The torch dtype to use when loading the model weights.",
+    )
+    optional_group.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="The device to use when loading the model.",
+    )
+
+
+class QuantizeCommand(BaseOptimumCLICommand):
+    @staticmethod
+    def parse_args(parser: "ArgumentParser"):
+        return parse_quantize_args(parser)
+
+    def run(self):
+        model_name_or_path = self.args.model
+        library_name = self.args.library
+        if library_name is None:
+            library_name = TasksManager.infer_library_from_model(model_name_or_path)
+        if library_name not in SUPPORTED_LIBRARIES:
+            raise ValueError(
+                f"{library_name} models are not supported by this CLI, but can be quantized using the python API directly."
+            )
+        task = self.args.task
+        if task is None:
+            task = TasksManager.infer_task_from_model(model_name_or_path)
+        torch_dtype = self.args.torch_dtype
+        if torch_dtype != "auto":
+            torch_dtype = torch.float16 if self.args.torch_dtype == "fp16" else torch.bfloat16
+        model = TasksManager.get_model_from_task(
+            task,
+            model_name_or_path,
+            revision=self.args.revision,
+            trust_remote_code=self.args.trust_remote_code,
+            framework="pt",
+            torch_dtype=torch_dtype,
+            device=torch.device(self.args.device),
+            library_name=library_name,
+            low_cpu_mem_usage=True,
+        )
+        weights = f"q{self.args.weights}"
+        qmodel = QuantizedTransformersModel.quantize(model, weights=weights)
+        qmodel.save_pretrained(self.args.output)

--- a/test/cli/cli_helpers.py
+++ b/test/cli/cli_helpers.py
@@ -1,0 +1,22 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+import pytest
+
+
+requires_optimum_cli = pytest.mark.skipif(
+    importlib.util.find_spec("optimum.commands") is None, reason="optimum-cli is required"
+)

--- a/test/cli/test_quantize_cli.py
+++ b/test/cli/test_quantize_cli.py
@@ -1,0 +1,49 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+from tempfile import TemporaryDirectory
+
+import pytest
+from cli_helpers import requires_optimum_cli
+
+from optimum.quanto import quantization_map
+
+
+@requires_optimum_cli
+@pytest.mark.parametrize("weights", ["int4", "int8"])
+def test_export_decoder_cli(weights):
+    from optimum.quanto import QuantizedModelForCausalLM
+
+    model_id = "facebook/opt-125m"
+    with TemporaryDirectory() as tempdir:
+        subprocess.run(
+            [
+                "optimum-cli",
+                "quanto",
+                "quantize",
+                "--model",
+                model_id,
+                "--weights",
+                f"{weights}",
+                tempdir,
+            ],
+            shell=False,
+            check=True,
+        )
+        # Verify we can reload the quantized model
+        qmodel = QuantizedModelForCausalLM.from_pretrained(tempdir)
+        qmap = quantization_map(qmodel)
+        for layer_qconfig in qmap.values():
+            assert layer_qconfig["weights"] == f"q{weights}"


### PR DESCRIPTION
# What does this PR do?

This adds a `subpackage` module that registers `quanto` commands to `optimum` CLI.

The subpackage contains for now only a very simple `quantize` command.

```shell
$ optimum-cli -h
usage: optimum-cli

positional arguments:
  {export,env,quanto}
    export             Export PyTorch and TensorFlow models to several format.
    env                Get information about the environment used.
    quanto             Hugging Face models quantization tools

optional arguments:
  -h, --help           show this help message and exit
```

```shell
$ optimum-cli quanto -h
usage: optimum-cli quanto [-h] {quantize} ...

positional arguments:
  {quantize}
    quantize  Quantize Hugging Face models.

optional arguments:
  -h, --help  show this help message and exit
```

```shell
$ optimum-cli quanto quantize -h
usage: optimum-cli quanto quantize [-h] -m MODEL [--weights {int2,int4,int8,float8}] [--revision REVISION] [--trust_remote_code] [--library {transformers}] [--task TASK]
                                   [--torch_dtype {auto,fp16,bf16}] [--device DEVICE]
                                   output

optional arguments:
  -h, --help            show this help message and exit

Required arguments:
  output                The path to save the quantized model.
  -m MODEL, --model MODEL
                        Hugging Face Hub model id or path to a local model.
  --weights {int2,int4,int8,float8}
                        The Hugging Face library to use to load the model.

Optional arguments:
  --revision REVISION   The Hugging Face model revision.
  --trust_remote_code   Trust remote code when loading the model.
  --library {transformers}
                        The Hugging Face library to use to load the model.
  --task TASK           The model task (useful for models supporting multiple tasks).
  --torch_dtype {auto,fp16,bf16}
                        The torch dtype to use when loading the model weights.
  --device DEVICE       The device to use when loading the model.
```