### PR TITLE
Fix TinyGemmQBitsTensor move

### DIFF
--- a/optimum/quanto/library/ext/cuda/__init__.py
+++ b/optimum/quanto/library/ext/cuda/__init__.py
@@ -85,7 +85,22 @@ def unpack_cuda(t: torch.Tensor, bits: int):
     return ext.lib.unpack(t, bits)
 
 
-@torch.library.impl("quanto_ext::gemm", ["CUDA"])
+torch.library.define(
+    "quanto::gemm",
+    "(Tensor input,"
+    " Tensor other,"
+    " Tensor other_scale,"
+    " Tensor other_shift,"
+    " int rows,"
+    " int out_cols,"
+    " int in_cols,"
+    " int bits,"
+    " int group_size)"
+    " -> Tensor",
+)
+
+
+@torch.library.impl("quanto::gemm", ["CUDA"])
 def gemm_cuda(
     input: torch.Tensor,
     other: torch.Tensor,

--- a/optimum/quanto/library/ops.py
+++ b/optimum/quanto/library/ops.py
@@ -68,16 +68,3 @@ def define(name, schema):
 
 
 define("unpack", "(Tensor self, int bits) -> Tensor")
-define(
-    "gemm",
-    "(Tensor input,"
-    " Tensor other,"
-    " Tensor other_scale,"
-    " Tensor other_shift,"
-    " int rows,"
-    " int out_cols,"
-    " int in_cols,"
-    " int bits,"
-    " int group_size)"
-    " -> Tensor",
-)

--- a/test/tensor/ops/test_linear_dispatch.py
+++ b/test/tensor/ops/test_linear_dispatch.py
@@ -53,11 +53,13 @@ def test_linear_gemm_fp16_int4(batch_size, tokens, embeddings, use_bias):
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(256, 256)])
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-def test_linear_tinygemm(batch_size, tokens, embeddings, use_bias, device):
+def test_linear_bf16_int4(batch_size, tokens, embeddings, use_bias, device):
     dtype = torch.bfloat16
     weight_qtype = qint4
-    inputs = torch.rand((batch_size,) + (tokens, embeddings), dtype=dtype, device=device)
-    qweight = random_qweight((embeddings, embeddings), weight_qtype, dtype=dtype, axis=0, group_size=128).to(device)
+    input_shape = (batch_size, tokens, embeddings)
+    inputs = torch.rand(input_shape, dtype=dtype, device=device)
+    weight_shape = (embeddings, embeddings)
+    qweight = random_qweight(weight_shape, weight_qtype, dtype=dtype, axis=0, group_size=128, device=device)
     bias = random_tensor((embeddings,), dtype=dtype).to(device) if use_bias else None
     qout = torch.nn.functional.linear(inputs, qweight, bias)
     out = torch.nn.functional.linear(inputs, qweight.dequantize(), bias)

--- a/test/tensor/qbits/test_tinygemm_packed_tensor.py
+++ b/test/tensor/qbits/test_tinygemm_packed_tensor.py
@@ -26,6 +26,8 @@ from optimum.quanto import TinyGemmPackedTensor
 @pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
 @pytest.mark.parametrize("random", [True, False])
 def test_pack_tinygemm_tensor(in_features, out_features, random, device):
+    if device.type == "cuda" and torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip(reason="CUDA device >= sm80 not available")
     bits = 4
     qmax = 2**bits
     shape = (out_features, in_features)
@@ -43,6 +45,8 @@ def test_pack_tinygemm_tensor(in_features, out_features, random, device):
 
 @pytest.mark.skip_device("mps")  # Only available with pytorch 2.4
 def test_move_tinygemm_packed_tensor(device):
+    if device.type == "cuda" and torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip(reason="CUDA device >= sm80 not available")
     shape = (256, 256)
     bits = 4
     qmax = 2**bits

--- a/test/tensor/qbits/test_tinygemm_qbits_tensor.py
+++ b/test/tensor/qbits/test_tinygemm_qbits_tensor.py
@@ -23,6 +23,8 @@ from optimum.quanto import TinyGemmQBitsTensor, qint4
 @pytest.mark.parametrize("in_features", [128, 256, 512, 1024])
 @pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
 def test_tinygemm_qbits_tensor_from_qbits_tensor(in_features, out_features, device):
+    if device.type == "cuda" and torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip(reason="CUDA device >= sm80 not available")
     qtype = qint4
     group_size = 128
     dtype = torch.bfloat16


### PR DESCRIPTION
# What does this PR do?

This fixes a few issues on CUDA with arch <= sm80: a TinyGemmQBitsTensor could be moved to the CUDA device without calling QBitsTensor::create.

A small change is also added to remove a dual dispatch for AWQ gemm. This slightly improves the decode latency for LLM (but does not impact much the end-to-end latency that is still dominated by the prefill latency).