### PR TITLE
fix(models): correct check for diffusers

### DIFF
--- a/optimum/quanto/__init__.py
+++ b/optimum/quanto/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.3dev"
+__version__ = "0.2.4dev"
 
 from .calibrate import *
 from .library import *

--- a/optimum/quanto/models/__init__.py
+++ b/optimum/quanto/models/__init__.py
@@ -27,5 +27,8 @@ def is_diffusers_available() -> bool:
 
 
 if is_transformers_available():
-    from .diffusers_models import *
     from .transformers_models import *
+
+
+if is_diffusers_available():
+    from .diffusers_models import *


### PR DESCRIPTION
# What does this PR do?

The diffusers models classes were previously imported even if the library was absent.