### PR TITLE
Fix a bug that prevents specifying include patterns for quantifying

### DIFF
--- a/optimum/quanto/quantize.py
+++ b/optimum/quanto/quantize.py
@@ -87,7 +87,7 @@ def quantize(
             any patterns from the denylist.
     """
     if include is not None:
-        include = [include] if isinstance(include, str) else exclude
+        include = [include] if isinstance(include, str) else include
     if exclude is not None:
         exclude = [exclude] if isinstance(exclude, str) else exclude
     for name, m in model.named_modules():


### PR DESCRIPTION
# What does this PR do?

I think the PR is self-explaining: you could not specify an include list in quantify, because include and exclude lists were swapped