### PR TITLE
feat: implement unpack sycl kernels with xpu extension

### DIFF
--- a/bench/generation/evaluate_configurations.py
+++ b/bench/generation/evaluate_configurations.py
@@ -85,6 +85,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/bench/generation/evaluate_model.py
+++ b/bench/generation/evaluate_model.py
@@ -117,6 +117,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/bench/kernels/benchmark.py
+++ b/bench/kernels/benchmark.py
@@ -39,6 +39,8 @@ def timing(get_bench_func, device, iterations=10):
             torch.cuda.synchronize()
         elif device.type == "mps":
             torch.mps.synchronize()
+        elif device.type == "xpu":
+            torch.xpu.synchronize()
         else:
             torch.cpu.synchronize()
 
@@ -47,6 +49,9 @@ def timing(get_bench_func, device, iterations=10):
             return torch.cuda.Event(enable_timing=True)
         elif device.type == "mps":
             return torch.mps.Event(enable_timing=True)
+        # See: https://github.com/pytorch/pytorch/issues/131840
+        # elif device.type == "xpu":
+        #     return torch.xpu.Event(enable_timing=True)
 
         class CPUEvent:
             def __init__(self):
@@ -99,6 +104,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/bench/torch_kernels/test_int_mm.py
+++ b/bench/torch_kernels/test_int_mm.py
@@ -32,6 +32,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/bench/torch_kernels/test_weight_int4pack_mm.py
+++ b/bench/torch_kernels/test_weight_int4pack_mm.py
@@ -76,6 +76,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/bench/torch_kernels/test_weight_int8pack_mm.py
+++ b/bench/torch_kernels/test_weight_int8pack_mm.py
@@ -32,6 +32,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/examples/nlp/text-classification/sst2/quantize_sst2_model.py
+++ b/examples/nlp/text-classification/sst2/quantize_sst2_model.py
@@ -62,6 +62,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/examples/nlp/text-generation/quantize_causal_lm_model.py
+++ b/examples/nlp/text-generation/quantize_causal_lm_model.py
@@ -112,6 +112,8 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -110,15 +110,17 @@ def main():
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:
         device = torch.device(args.device)
 
     dataset_kwargs = {"batch_size": args.batch_size}
-    if torch.cuda.is_available():
-        cuda_kwargs = {"num_workers": 1, "pin_memory": True, "shuffle": True}
-        dataset_kwargs.update(cuda_kwargs)
+    if torch.cuda.is_available() or torch.xpu.is_available():
+        backend_kwargs = {"num_workers": 1, "pin_memory": True, "shuffle": True}
+        dataset_kwargs.update(backend_kwargs)
 
     transform = transforms.Compose(
         [

--- a/examples/vision/object-detection/quantize_owl_model.py
+++ b/examples/vision/object-detection/quantize_owl_model.py
@@ -58,6 +58,11 @@ def get_device_memory(device):
     elif device.type == "mps":
         torch.mps.empty_cache()
         return torch.mps.current_allocated_memory()
+    elif device.type == "xpu":
+        torch.xpu.empty_cache()
+        # See: https://github.com/pytorch/pytorch/issues/127929
+        # return torch.xpu.current_allocated_memory()
+        return None
     return None
 
 
@@ -81,6 +86,8 @@ def main():
         elif torch.backends.mps.is_available():
             # MPS backend does not support torch.float64 that is required for owl models
             device = torch.device("cpu")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/examples/vision/text-to-image/quantize_pixart_sigma.py
+++ b/examples/vision/text-to-image/quantize_pixart_sigma.py
@@ -39,6 +39,11 @@ def get_device_memory(device):
     elif device.type == "mps":
         torch.mps.empty_cache()
         return torch.mps.current_allocated_memory()
+    elif device.type == "xpu":
+        torch.xpu.empty_cache()
+        # See: https://github.com/pytorch/pytorch/issues/127929
+        # return torch.mps.current_allocated_memory()
+        return None
     return None
 
 
@@ -56,6 +61,8 @@ if __name__ == "__main__":
             device = torch.device("cuda")
         elif torch.backends.mps.is_available():
             device = torch.device("mps")
+        elif torch.xpu.is_available():
+            device = torch.device("xpu")
         else:
             device = torch.device("cpu")
     else:

--- a/optimum/quanto/library/extensions/xpu/pybind_module.cpp
+++ b/optimum/quanto/library/extensions/xpu/pybind_module.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024 The HuggingFace Team. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <torch/extension.h>
+#include "unpack.h"
+
+// !IMPORTANT! Some python objects such as dtype, device, are not mapped to C++ types,
+// and need to be explicitly converted using dedicated helpers before calling a C++ method.
+// As a consequence, when an operation takes such an object as parameter, instead
+// of creating a binding directly to the C++ method, you must create a binding to a
+// lambda method that converts the unmapped types and calls the C++ method.
+// See the binding of quantize_symmetric for instance.
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("unpack", &unpack, "unpack");
+}

--- a/optimum/quanto/library/extensions/xpu/unpack.h
+++ b/optimum/quanto/library/extensions/xpu/unpack.h
@@ -1,0 +1,17 @@
+// Copyright 2024 The HuggingFace Team. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <torch/extension.h>
+
+torch::Tensor unpack(torch::Tensor &t, int bits);

--- a/optimum/quanto/library/extensions/xpu/unpack.sycl
+++ b/optimum/quanto/library/extensions/xpu/unpack.sycl
@@ -1,0 +1,150 @@
+// Copyright 2024 The HuggingFace Team. All rights reserved.
+// Copyright 2024 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <torch/extension.h>
+#include <sycl/sycl.hpp>
+#include <c10/xpu/XPUStream.h>
+
+
+inline unsigned int cdiv(unsigned int a, unsigned int b) { return (a + b - 1) / b;}
+#define BLOCK_SIZE 256
+
+using namespace at;
+
+
+static torch::Tensor allocate_output(const torch::Tensor& input, int bits) {
+    int n_packed = 8 / bits;
+    auto output_shape = input.sizes().vec();
+    output_shape[0] = output_shape[0] * n_packed;
+    return torch::empty(output_shape, input.options());
+}
+
+void unpack_4bit_kernel(unsigned char* input, unsigned char* output, int n,
+                        const sycl::nd_item<3> &item_ct1) {
+    int i = item_ct1.get_group(2) * item_ct1.get_local_range(2) +
+            item_ct1.get_local_id(2);
+    if (i>=n) return;
+
+    output[i]     = (input[i] & 0x0F);
+    output[i + n] = (input[i] & 0xF0) >> 4;
+}
+
+class Unpack4BitKrn {
+public:
+    void operator()(sycl::nd_item<3> item_ct1) const {
+        unpack_4bit_kernel(ct0, ct1, numel, item_ct1);
+    }
+    Unpack4BitKrn(unsigned char* _ct0, unsigned char* _ct1, int64_t _numel):
+        ct0(_ct0),
+        ct1(_ct1),
+        numel(_numel)
+    {}
+private:
+    unsigned char* ct0;
+    unsigned char* ct1;
+    int64_t numel;
+};
+
+static torch::Tensor unpack_4bit(const torch::Tensor& input){
+    auto output = allocate_output(input, 4);
+
+    const auto numel = input.numel();
+    int blocks = cdiv(numel, BLOCK_SIZE);
+
+    sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue();
+
+    auto krn = [&](sycl::handler &cgh) {
+        auto input_data_ptr_unsigned_char_ct0 =
+            input.data_ptr<unsigned char>();
+        auto output_data_ptr_unsigned_char_ct1 =
+            output.data_ptr<unsigned char>();
+
+	Unpack4BitKrn krn2(input_data_ptr_unsigned_char_ct0, output_data_ptr_unsigned_char_ct1, numel);
+
+        cgh.parallel_for<Unpack4BitKrn>(
+            sycl::nd_range<3>(
+		sycl::range<3>(1, 1, blocks) * sycl::range<3>(1, 1, BLOCK_SIZE),
+                sycl::range<3>(1, 1, BLOCK_SIZE)),
+	    krn2);
+    };
+    queue.submit(krn);
+    return output;
+}
+
+void unpack_2bit_kernel(unsigned char* input, unsigned char* output, int n,
+                        const sycl::nd_item<3> &item_ct1) {
+    int i = item_ct1.get_group(2) * item_ct1.get_local_range(2) +
+            item_ct1.get_local_id(2);
+    if (i>=n) return;
+
+    output[i]       = (input[i] & 0x03);
+    output[i + n]   = (input[i] & 0x0C) >> 2;
+    output[i + n*2] = (input[i] & 0x30) >> 4;
+    output[i + n*3] = (input[i] & 0xC0) >> 6;
+}
+
+class Unpack2BitKrn {
+public:
+    void operator()(sycl::nd_item<3> item_ct1) const {
+        unpack_2bit_kernel(ct0, ct1, numel, item_ct1);
+    }
+    Unpack2BitKrn(unsigned char* _ct0, unsigned char* _ct1, int64_t _numel):
+        ct0(_ct0),
+        ct1(_ct1),
+        numel(_numel)
+    {}
+private:
+    unsigned char* ct0;
+    unsigned char* ct1;
+    int64_t numel;
+};
+
+static torch::Tensor unpack_2bit(const torch::Tensor& input){
+    auto output = allocate_output(input, 2);
+
+    const auto numel = input.numel();
+    int blocks = cdiv(numel, BLOCK_SIZE);
+    sycl::queue& queue = c10::xpu::getCurrentXPUStream().queue();
+    auto krn = [&](sycl::handler &cgh) {
+        auto input_data_ptr_unsigned_char_ct0 =
+            input.data_ptr<unsigned char>();
+        auto output_data_ptr_unsigned_char_ct1 =
+            output.data_ptr<unsigned char>();
+
+	Unpack2BitKrn krn2(input_data_ptr_unsigned_char_ct0, output_data_ptr_unsigned_char_ct1, numel);
+
+        cgh.parallel_for<Unpack2BitKrn>(
+            sycl::nd_range<3>(
+		sycl::range<3>(1, 1, blocks) * sycl::range<3>(1, 1, BLOCK_SIZE),
+                sycl::range<3>(1, 1, BLOCK_SIZE)),
+	    krn2);
+    };
+    queue.submit(krn);
+    return output;
+}
+
+torch::Tensor unpack(torch::Tensor &t, int bits) {
+    TORCH_CHECK(t.scalar_type() == torch::kUInt8, "Unsupported data type: ", t.scalar_type());
+    TORCH_CHECK(t.device().is_xpu(), "t must be a XPU  tensor.");
+    TORCH_CHECK(t.is_contiguous(), "t must be contiguous.");
+    switch(bits) {
+      case 4:
+        return unpack_4bit(t);
+      case 2:
+        return unpack_2bit(t);
+      default:
+        throw std::invalid_argument("Can only unpack 2-bit or 4-bit tensors.");
+    }
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,8 @@ if torch.cuda.is_available():
     devices += ["cuda"]
 elif torch.backends.mps.is_available():
     devices += ["mps"]
+elif torch.xpu.is_available():
+    devices += ["xpu"]
 
 
 @pytest.fixture(scope="module", params=devices)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -106,4 +106,9 @@ def get_device_memory(device):
     elif device.type == "mps":
         torch.mps.empty_cache()
         return torch.mps.current_allocated_memory()
+    elif device.type == "xpu":
+        torch.xpu.empty_cache()
+        # See: https://github.com/pytorch/pytorch/issues/127929
+        # return torch.xpu.current_allocated_memory()
+        return None
     return None

--- a/test/library/test_extensions.py
+++ b/test/library/test_extensions.py
@@ -9,6 +9,8 @@ if torch.cuda.is_available():
     extension_types.append("cuda")
 if torch.backends.mps.is_available():
     extension_types.append("mps")
+if torch.xpu.is_available():
+    extension_types.append("xpu")
 
 
 @pytest.mark.parametrize("extension_type", extension_types)


### PR DESCRIPTION
This commit implements xpu extension with unpack kernels written in sycl. Pytorch XPU backend provides hw acceleration on Intel GPUs. At the moment Meteor Lake (MTL) and Data Center Max (PVC) are supported. Provided sycl kernel was converted from existing cuda kernel.
```
$ python bench/kernels/benchmark.py --it 1000
unpack_2bit[xpu]: python = 0.177 ms, ext = 0.033 ms, ratio = 5.4x
unpack_4bit[xpu]: python = 0.085 ms, ext = 0.026 ms, ratio = 3.3x
```
note: without extension ratio is 0.8x.

At the moment there are few not implemented features for xpu backend which affect implementation. These are:
* https://github.com/pytorch/pytorch/issues/127929
  * Some memory ops not supported by xpu backend
  * WA applied: calling these ops is commented out
* https://github.com/pytorch/pytorch/issues/131840
  * elapsed_time is not supported by `XPUEvent`
  * WA applied: calling these ops is commented out (CPU e2e time is measured)
* https://github.com/pytorch/pytorch/issues/132947
  * Some aten ops are not implemented with xpu backend falling back to cpu
  * WA required: set `PYTORCH_ENABLE_XPU_FALLBACK=1` on cmdline

IMPORTANT: this PR requires support to build sycl kernels via `torch.utils.cpp_extension.load` API which currently is not available in upstream pytorch. The request was made in https://github.com/pytorch/pytorch/issues/132944 with implementation provided via https://github.com/pytorch/pytorch/pull/132945. This is prerequisite to merge the PR here on quanto side. For that reason I open it as a draft.

Requires: https://github.com/pytorch/pytorch/pull/132945

CC: @gujinghui @EikanWang @fengyuan14 @guangyey @jgong5 @dacorvo