### PR TITLE
Support torch>=2.3.0

### DIFF
--- a/optimum/quanto/library/quantize.py
+++ b/optimum/quanto/library/quantize.py
@@ -19,7 +19,6 @@ import torch
 from ..tensor import dtype_info, group
 
 
-@torch.library.custom_op("quanto::quantize_symmetric", mutates_args=())
 def quantize_symmetric(
     base: torch.Tensor, dtype: torch.dtype, axis: Union[int, None], scale: torch.Tensor
 ) -> torch.Tensor:
@@ -50,7 +49,6 @@ def quantize_symmetric(
     return torch.clamp(data, min=info.min, max=info.max).to(dtype)
 
 
-@torch.library.custom_op("quanto::quantize_affine", mutates_args=())
 def quantize_affine(
     base: torch.Tensor, bits: int, axis: int, group_size: Union[int, None], scale: torch.Tensor, shift: torch.Tensor
 ) -> torch.Tensor:
@@ -65,3 +63,6 @@ def quantize_affine(
         data = torch.round(base / scale) + shift
 
     return torch.clamp(data, min=0, max=2**bits - 1).to(torch.uint8)
+
+torch.ops.quanto.quantize_symmetric = quantize_symmetric
+torch.ops.quanto.quantize_affine = quantize_affine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [{ name = 'David Corvoysier' }]
 maintainers = [
     {name = "HuggingFace Inc. Special Ops Team", email="hardware@huggingface.co"},
 ]
-dependencies = ['torch>=2.4.0', 'ninja', 'numpy', 'safetensors', 'huggingface_hub']
+dependencies = ['torch>=2.3.0', 'ninja', 'numpy', 'safetensors', 'huggingface_hub']
 license = { text = 'Apache-2.0' }
 readme = 'README.md'
 dynamic = ['version']


### PR DESCRIPTION
The decorator syntax added for quantize_symmetric and quantize_affine are only supported on 2.4+.

I'm trying to use the `from_pretrained` feature for pulling the quantized models from HF, specifically for FLUX.

But the problem is, FLUX currently has issues with Torch2.4, generating grainy images. So if we want to be able to use this from_pretrained feature to pull quantized FLUX models from the hub, we need to use torch 2.3.1, which means using the old syntax instead of the decorator syntax.

More on this issue here: https://github.com/huggingface/diffusers/issues/9047