### PR TITLE
perf: faster and less memory-intensive model [re]quantization

### DIFF
--- a/optimum/quanto/quantize.py
+++ b/optimum/quanto/quantize.py
@@ -133,12 +133,11 @@ def requantize(
             setattr(m, name, torch.nn.Parameter(move_tensor(param, "cpu")))
         for name, param in m.named_buffers(recurse=False):
             setattr(m, name, move_tensor(param, "cpu"))
-    # Freeze model and move to target device
-    freeze(model)
-    model.to(device)
 
     # Load the quantized model weights
     model.load_state_dict(state_dict, strict=False)
+    # Move to target device
+    model.to(device)
 
 
 def freeze(model):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [{ name = 'David Corvoysier' }]
 maintainers = [
     {name = "HuggingFace Inc. Special Ops Team", email="hardware@huggingface.co"},
 ]
-dependencies = ['torch>=2.4.0', 'ninja', 'numpy', 'safetensors']
+dependencies = ['torch>=2.4.0', 'ninja', 'numpy', 'safetensors', 'accelerate']
 license = { text = 'Apache-2.0' }
 readme = 'README.md'
 dynamic = ['version']


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Currently optimum.quanto's quantize/requantize functions run slowly for large models as quantized modules (e.g. QLinear) are initialized with random weights which immediately get replaced with pretrained weights. This also causes these methods to use more CPU RAM than necessary (which is especially visible with models whose weights are lazily loaded). This PR essentially makes quantize/requantize run instantly while using less RAM for lazily-loaded models.

### Repro
```python
from optimum.quanto import quantize, requantize, freeze, quantization_map, qint8
from safetensors.torch import save_model, load_file
from diffusers import FluxPipeline
from copy import deepcopy
import torch.nn as nn
import psutil
import torch
import json
import time

torch.random.manual_seed(0)
def free_mem(): return psutil.virtual_memory().available # get current amount of free RAM

# using Flux as its weights are lazily loaded
pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-schnell", torch_dtype=torch.bfloat16)
pipe_copy = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-schnell", torch_dtype=torch.bfloat16)
# text_encoder_2 = T5 encoder
model = pipe.text_encoder_2
model_copy = pipe_copy.text_encoder_2

# test quantization speed and memory usage
start_mem = free_mem()
tic = time.perf_counter()
quantize(model, weights=qint8)
print(f'quantize duration: {time.perf_counter() - tic:.3f} s, extra ram usage: {(start_mem - free_mem())/1e6:.3f} MB')

# test model freezing speed and memory usage
start_mem = free_mem()
tic = time.perf_counter()
freeze(model)
print(f'freeze duration: {time.perf_counter() - tic:.3f} s, extra ram usage: {(start_mem - free_mem())/1e6:.3f} MB')

# save model + qmap
save_model(model, '/tmp/model.sft')
with open('/tmp/qmap.json', 'w') as f:
    json.dump(quantization_map(model), f)

# load weight files
state_dict = load_file('/tmp/model.sft')
with open('/tmp/qmap.json', 'r') as f:
    qmap = json.load(f)

# test requantization speed and memory usage
start_mem = free_mem()
tic = time.perf_counter()
requantize(model_copy, state_dict, qmap)
print(f'requantize duration: {time.perf_counter() - tic:.3f} s, extra ram usage: {(start_mem - free_mem())/1e6:.3f} MB')

# make sure that quantized and requantized models have same parameters
for (n1, p1), (n2, p2) in zip(model.named_parameters(), model_copy.named_parameters()):
    assert (p1-p2).sum() == 0
```
### Results for above code (before fix)
| Op | Duration (s) | CPU RAM Usage (MB) |
|------|-----------------|-------------------------------|
|quantize|41.66|9211.67|
|requantize|44.948|1999.847|

### Results for above code (after fix)
| Op | Duration (s) | CPU RAM Usage (MB) |
|------|-----------------|-------------------------------|
|quantize|0.024|3.867|
|requantize|0.130|265.83|

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/optimum-quanto/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you run all tests locally and make sure they pass.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
