### PR TITLE
Avoid random weights initialization when quantizing

### DIFF
--- a/optimum/quanto/nn/qconv2d.py
+++ b/optimum/quanto/nn/qconv2d.py
@@ -27,7 +27,12 @@ __all__ = ["QConv2d"]
 class QConv2d(QModuleMixin, torch.nn.Conv2d):
     @classmethod
     def qcreate(
-        cls, module, weights: qtype, activations: Optional[qtype] = None, optimizer: Optional[Optimizer] = None
+        cls,
+        module,
+        weights: qtype,
+        activations: Optional[qtype] = None,
+        optimizer: Optional[Optimizer] = None,
+        device: Optional[torch.device] = None,
     ):
         return cls(
             in_channels=module.in_channels,
@@ -40,7 +45,7 @@ class QConv2d(QModuleMixin, torch.nn.Conv2d):
             bias=module.bias is not None,
             padding_mode=module.padding_mode,
             dtype=module.weight.dtype,
-            device=module.weight.device,
+            device=device,
             weights=weights,
             activations=activations,
             optimizer=optimizer,

--- a/optimum/quanto/nn/qlayernorm.py
+++ b/optimum/quanto/nn/qlayernorm.py
@@ -32,6 +32,7 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
         weights: Optional[qtype] = None,
         activations: Optional[qtype] = None,
         optimizer: Optional[Optimizer] = None,
+        device: Optional[torch.device] = None,
     ):
         if activations is None:
             return None
@@ -41,7 +42,7 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
             module.elementwise_affine,
             module.bias is not None,
             dtype=module.weight.dtype,
-            device=module.weight.device,
+            device=device,
             weights=None,  # We never quantize QLayerNorm weights
             activations=activations,
             optimizer=None,  # We never quantize QLayerNorm weights

--- a/optimum/quanto/nn/qlinear.py
+++ b/optimum/quanto/nn/qlinear.py
@@ -27,14 +27,19 @@ __all__ = ["QLinear"]
 class QLinear(QModuleMixin, torch.nn.Linear):
     @classmethod
     def qcreate(
-        cls, module, weights: qtype, activations: Optional[qtype] = None, optimizer: Optional[Optimizer] = None
+        cls,
+        module,
+        weights: qtype,
+        activations: Optional[qtype] = None,
+        optimizer: Optional[Optimizer] = None,
+        device: Optional[torch.device] = None,
     ):
         return cls(
             module.in_features,
             module.out_features,
             module.bias is not None,
             dtype=module.weight.dtype,
-            device=module.weight.device,
+            device=device,
             weights=weights,
             activations=activations,
             optimizer=optimizer,


### PR DESCRIPTION
# What does this PR do?

As raised by @latentCall145, there is a useless random weights initialization when quantizing a module.
The solution suggested in #290 is correct but makes the low-level quantization API depend on `accelerate`, which is only an optional dependency used by the high-level model API.

This is more or less the same implementation, but more explicitly using the `meta` device. Note that we need to explicitly preserve the scales, since unlike `accelerate`, pytorch does not distinguish between parameters and buffers when skipping initialization.