### PR TITLE
FIX: Enable non-strict loading of state dicts

### DIFF
--- a/optimum/quanto/tensor/qbits/packed.py
+++ b/optimum/quanto/tensor/qbits/packed.py
@@ -111,7 +111,11 @@ class PackedTensor(torch.Tensor):
         return torch.uint8
 
     @staticmethod
-    def load_from_state_dict(state_dict, prefix, bits, size, stride):
+    def load_from_state_dict(state_dict, prefix, bits, size, stride, missing_keys):
+        if prefix + "_data" not in state_dict:
+            missing_keys.append(prefix + "_data")
+            return
+
         inner_tensors_dict = {"_data": state_dict.pop(prefix + "_data")}
         meta = [name.replace(prefix, "") for name in state_dict.keys() if name.startswith(prefix)]
         meta = {"bits": str(bits), "size": str(list(size)), "stride": str(stride)}

--- a/optimum/quanto/tensor/qbits/qbits.py
+++ b/optimum/quanto/tensor/qbits/qbits.py
@@ -165,7 +165,7 @@ class QBitsTensor(QTensor):
         return QBitsDequantizer.apply(self)
 
     @staticmethod
-    def load_from_state_dict(state_dict, prefix, qtype, axis, group_size, size, stride):
+    def load_from_state_dict(state_dict, prefix, qtype, axis, group_size, size, stride, missing_keys):
         if group_size is None:
             data_size = size
             data_stride = stride
@@ -176,11 +176,20 @@ class QBitsTensor(QTensor):
             data_stride = (data_size[1], 1)
         inner_tensors_dict = {
             "_data": PackedTensor.load_from_state_dict(
-                state_dict, prefix + "_data.", qtype.bits, data_size, data_stride
+                state_dict, prefix + "_data.", qtype.bits, data_size, data_stride, missing_keys=missing_keys
             )
         }
+        missing = inner_tensors_dict["_data"] is None
         for name in ["_scale", "_shift"]:
-            inner_tensors_dict[name] = state_dict.pop(prefix + name)
+            if prefix + name not in state_dict:
+                missing_keys.append(prefix + name)
+                missing = True
+            else:
+                inner_tensors_dict[name] = state_dict.pop(prefix + name)
+
+        if missing:  # could not deserialize because of missing keys
+            return None
+
         meta = {
             "qtype": qtype.name,
             "axis": str(axis),


### PR DESCRIPTION
# What does this PR do?

Resolves #278

PyTorch allows to load state dicts with they strict=False argument to ignore missing keys. This is now also supported in optimum-quanto. Before this fix, a KeyError would be raised.

One context where this is important is for parameter-efficient fine-tuning adapters such as LoRA. There, we want to load only a small subset of parameters and leave the other model weights untouched. This requires non-strict loading.


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/optimum-quanto/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] ~Did you run all tests locally and make sure they pass.~ Only subset
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
