### PR TITLE
Fix transformer model forward error

### DIFF
--- a/optimum/quanto/models/transformers_models.py
+++ b/optimum/quanto/models/transformers_models.py
@@ -54,7 +54,7 @@ class QuantizedTransformersModel(ModelHubMixin):
             return getattr(wrapped, name)
 
     def forward(self, *args, **kwargs):
-        return self.model.forward(*args, **kwargs)
+        return self._wrapped.forward(*args, **kwargs)
 
     @staticmethod
     def _qmap_name():

--- a/optimum/quanto/nn/qmodule.py
+++ b/optimum/quanto/nn/qmodule.py
@@ -131,8 +131,8 @@ class QModuleMixin(ABC):
                 self._quantize_hooks["input"] = self.register_forward_pre_hook(self.quantize_input)
             self._quantize_hooks["output"] = self.register_forward_hook(self.quantize_output)
         self.optimizer = optimizer
-        self.register_buffer("input_scale", torch.ones((), device=device))
-        self.register_buffer("output_scale", torch.ones((), device=device))
+        self.register_buffer("input_scale", torch.ones((), dtype=self.weight.dtype, device=device))
+        self.register_buffer("output_scale", torch.ones((), dtype=self.weight.dtype, device=device))
 
     def disable_output_quantization(self):
         if "output" in self._quantize_hooks:

--- a/test/models/test_quantized_model_for_causal_lm.py
+++ b/test/models/test_quantized_model_for_causal_lm.py
@@ -65,7 +65,7 @@ def compare_models(a_model, b_model):
     with torch.no_grad():
         output_a = a_model.forward(inputs)
         output_b = b_model.forward(inputs)
-    assert torch.equal(output_a.last_hidden_state, output_b.last_hidden_state)
+    assert torch.equal(output_a.logits, output_b.logits)
     for i, a_key_value in enumerate(output_a.past_key_values):
         b_key_value = output_b.past_key_values[i]
         for j, a_value in enumerate(a_key_value):


### PR DESCRIPTION
# What does this PR do?

This fixes `QuantizedTransformerModel` inference to avoid omitting the lm_head (forward was always using the headless model).

This also fixes a minor bug that led to type mismatch on models with quantized activations that were not calibrated.