### PR TITLE
fix(library): disable int_mm for CPU

### DIFF
--- a/optimum/quanto/library/qbytes_mm.py
+++ b/optimum/quanto/library/qbytes_mm.py
@@ -91,8 +91,8 @@ def qbytes_mm_impl_cuda(activations: torch.Tensor, weights: torch.Tensor, output
 @torch.library.impl("quanto::qbytes_mm", "CPU")
 def qbytes_mm_impl_cpu(activations: torch.Tensor, weights: torch.Tensor, output_scales: torch.Tensor) -> torch.Tensor:
     if (
-        # FIXME: accuracy issues with 2.4.0
-        version.parse(torch.__version__).release > version.parse("2.4.0").release
+        # FIXME: accuracy issues with 2.4.x
+        version.parse(torch.__version__).release > version.parse("2.4.1").release
         and activations.dtype == torch.int8
         and weights.dtype == torch.int8
     ):


### PR DESCRIPTION
The CPU implementation still has accuracy issues with pytorch 2.4.1.