### PR TITLE
Add marlin int4 kernel

### DIFF
--- a/optimum/quanto/library/extensions/cuda/__init__.py
+++ b/optimum/quanto/library/extensions/cuda/__init__.py
@@ -60,6 +60,8 @@ sources = [
     "awq/v2/gemv_cuda.cu",
     "marlin/fp8_marlin.cu",
     "marlin/gptq_marlin_repack.cu",
+    "marlin/marlin_cuda.cpp",
+    "marlin/marlin_cuda_kernel.cu",
     "pybind_module.cpp",
 ]
 ext = Extension(

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.cpp
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.cpp
@@ -30,6 +30,7 @@ void mul(
   const torch::Tensor& B,
         torch::Tensor& C,
   const torch::Tensor& s,
+  const torch::Tensor& sz, // ADDED: add scaled zero point
         torch::Tensor& workspace,
   int thread_k,
   int thread_n,
@@ -50,6 +51,7 @@ void mul(
     B.data_ptr(),
     C.data_ptr(),
     s.data_ptr(),
+    sz.data_ptr(), // ADDED: add scaled zero point
     prob_m, prob_n, prob_k,
     workspace.data_ptr(),
     groupsize,

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.cpp
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "marlin_cuda.h"
+
+#include <torch/all.h>
+#include <torch/python.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+
+#include "marlin_cuda_kernel.cuh"
+
+const int ERR_PROB_SHAPE = 1;
+const int ERR_KERN_SHAPE = 2;
+
+void mul(
+  const torch::Tensor& A,
+  const torch::Tensor& B,
+        torch::Tensor& C,
+  const torch::Tensor& s,
+        torch::Tensor& workspace,
+  int thread_k,
+  int thread_n,
+  int sms,
+  int max_par
+) {
+  int prob_m = A.size(0);
+  int prob_n = C.size(1);
+  int prob_k = A.size(1);
+  int groupsize = (s.size(0) == 1) ? -1 : prob_k / s.size(0);
+  if (groupsize != -1 && groupsize * s.size(0) != prob_k)
+    AT_ERROR("k=", prob_k, " not compatible with ", s.size(0), " groups.");
+  if (workspace.numel() < prob_n / 128 * max_par)
+    AT_ERROR("workspace must be of size at least ", prob_n / 128 * max_par, ".");
+  int dev = A.get_device();
+  int err = marlin_cuda(
+    A.data_ptr(),
+    B.data_ptr(),
+    C.data_ptr(),
+    s.data_ptr(),
+    prob_m, prob_n, prob_k,
+    workspace.data_ptr(),
+    groupsize,
+    dev,
+    at::cuda::getCurrentCUDAStream(dev),
+    thread_k,
+    thread_n,
+    sms,
+    max_par
+  );
+  if (err == ERR_PROB_SHAPE) {
+    AT_ERROR(
+      "Problem (m=", prob_m, ", n=", prob_n, ", k=", prob_k, ")",
+      " not compatible with thread_k=", thread_k, ", thread_n=", thread_n, "."
+    );
+  } else if (err == ERR_KERN_SHAPE) {
+    AT_ERROR(
+      "No kernel implementation for thread_k=", thread_k, ", thread_n=", thread_n, ", groupsize=", groupsize, "."
+    );
+  }
+}

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.h
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <torch/extension.h>
+
+void mul(
+  const torch::Tensor& A,
+  const torch::Tensor& B,
+        torch::Tensor& C,
+  const torch::Tensor& s,
+        torch::Tensor& workspace,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 8
+);

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.h
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda.h
@@ -20,6 +20,7 @@ void mul(
   const torch::Tensor& B,
         torch::Tensor& C,
   const torch::Tensor& s,
+  const torch::Tensor& sz,
         torch::Tensor& workspace,
   int thread_k = -1,
   int thread_n = -1,

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda_kernel.cu
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda_kernel.cu
@@ -1,0 +1,822 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef MARLIN_CUDA_KERNEL_CUH
+#define MARLIN_CUDA_KERNEL_CUH
+
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <iostream>
+
+
+constexpr int ceildiv(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+// Instances of `Vec` are used to organize groups of >>registers<<, as needed for instance as inputs to tensor core
+// operations. Consequently, all corresponding index accesses must be compile-time constants, which is why we
+// extensively use `#pragma unroll` throughout the kernel code to guarantee this.
+template <typename T, int n>
+struct Vec {
+  T elems[n];
+  __device__ T& operator[](int i) {
+    return elems[i];
+  }
+};
+
+using I4 = Vec<int, 4>;
+
+// Matrix fragments for tensor core instructions; their precise layout is documented here:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+using FragA = Vec<half2, 4>;
+using FragB = Vec<half2, 2>;
+using FragC = Vec<float, 4>;
+using FragS = Vec<half2, 1>; // quantization scales
+
+// Predicated asynchronous global->shared copy; used for inputs A where we apply predication to handle batchsizes that
+// are not multiples of 16.
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .pred p;\n"
+    "   setp.ne.b32 p, %0, 0;\n"
+    "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+    "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Asynchronous global->shared copy with a cache hint indicating that the values may be evicted immediately; used for
+// quantized weights B, which are only accessed precisely once and should thus not pollute the L2 cache which we need
+// for inputs A and outputs C.
+__device__ inline void cp_async4_stream(void* smem_ptr, const void* glob_ptr) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .b64 p;\n"
+    "   createpolicy.fractional.L2::evict_first.b64 p, 1.0;"
+    "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
+    "}\n" :: "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Async copy fence.
+__device__ inline void cp_async_fence() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+// Wait until at most `n` async copy stages are still pending.
+template <int n>
+__device__ inline void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
+}
+
+// m16n8k16 tensor core mma instruction with fp16 inputs and fp32 output/accumulation.
+__device__ inline void mma(const FragA& a_frag, const FragB& frag_b, FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  asm volatile(
+    "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+    : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+    :  "r"(a[0]),  "r"(a[1]),  "r"(a[2]),  "r"(a[3]),  "r"(b[0]),  "r"(b[1]),
+       "f"(c[0]),  "f"(c[1]),  "f"(c[2]),  "f"(c[3])
+  );
+}
+
+// Instruction for loading a full 16x16 matrix fragment of operand A from shared memory, directly in tensor core layout.
+__device__ inline void ldsm4(FragA& frag_a, const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+    : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) : "r"(smem)
+  );
+}
+
+// Lookup-table based 3-input logical operation; explicitly used for dequantization as the compiler does not seem to
+// automatically recognize it in all cases.
+template <int lut>
+__device__ inline int lop3(int a, int b, int c) {
+  int res;
+  asm volatile(
+    "lop3.b32 %0, %1, %2, %3, %4;\n"
+    : "=r"(res) : "r"(a), "r"(b), "r"(c), "n"(lut)
+  );
+  return res;
+}
+
+// Efficiently dequantize an int32 value into a full B-fragment of 4 fp16 values.
+// We mostly follow the strategy in the link below, with some small changes:
+// https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+__device__ inline FragB dequant(int q) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point directly into `SUB` and `ADD`.
+  const int SUB = 0x64086408;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd480d480;
+  FragB frag_b;
+  frag_b[0] = __hsub2(
+    *reinterpret_cast<half2*>(&lo),
+    *reinterpret_cast<const half2*>(&SUB)
+  );
+  frag_b[1] = __hfma2(
+    *reinterpret_cast<half2*>(&hi),
+    *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD)
+  );
+  return frag_b;
+}
+
+// Multiply dequantized values by the corresponding quantization scale; used only for grouped quantization.
+__device__ inline void scale(FragB& frag_b, FragS& frag_s, int i) {
+  half2 s = __half2half2(reinterpret_cast<__half*>(&frag_s)[i]);
+  frag_b[0] = __hmul2(frag_b[0], s);
+  frag_b[1] = __hmul2(frag_b[1], s);
+}
+
+// Wait until barrier reaches `count`, then lock for current threadblock.
+__device__ inline void barrier_acquire(int* lock, int count) {
+  if (threadIdx.x == 0) {
+    int state = -1;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible globally.
+      asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    while (state != count);
+  }
+  __syncthreads();
+}
+
+// Release barrier and increment visitation count.
+__device__ inline void barrier_release(int* lock, bool reset = false) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    if (reset) {
+      lock[0] = 0;
+      return;
+    }
+    int val = 1;
+    // Make sure that all writes since acquiring this barrier are visible globally, while releasing the barrier.
+    asm volatile ("fence.acq_rel.gpu;\n");
+    asm volatile ("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val));
+  }
+}
+
+
+template <
+  const int threads, // number of threads in a threadblock
+  const int thread_m_blocks, // number of 16x16 blocks in the m dimension (batchsize) of the threadblock
+  const int thread_n_blocks, // same for n dimension (output)
+  const int thread_k_blocks, // same for k dimension (reduction)
+  const int stages, // number of stages for the async global->shared fetch pipeline
+  const int group_blocks = -1 // number of consecutive 16x16 blocks with a separate quantization scale
+>
+__global__ void Marlin(
+  const int4* __restrict__ A, // fp16 input matrix of shape mxk
+  const int4* __restrict__ B, // 4bit quantized weight matrix of shape kxn
+        int4* __restrict__ C, // fp16 output buffer of shape mxn
+  const int4* __restrict__ s, // fp16 quantization scales of shape (k/groupsize)xn
+  int  prob_m, // batch dimension m
+  int  prob_n, // output dimension n
+  int  prob_k, // reduction dimension k
+  int* locks // extra global storage for barrier synchronization
+) {
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the same size, which might involve multiple
+  // column "slices" (of width 16 * `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM example:
+  //   0 1 3
+  //   0 2 3
+  //   1 2 4
+  // While this kind of partitioning makes things somewhat more complicated, it ensures good utilization of all SMs
+  // for many kinds of shape and GPU configurations, while requiring as few slow global cross-threadblock reductions as
+  // possible.
+
+  // For larger GEMMs we run multiple batchsize 64 versions in parallel for a better partitioning with less reductions
+  int parallel = 1;
+  if (prob_m > 16 * thread_m_blocks) {
+    parallel = prob_m / (16 * thread_m_blocks);
+    prob_m = 16 * thread_m_blocks;
+  }
+
+  int k_tiles = prob_k / 16 / thread_k_blocks;
+  int n_tiles = prob_n / 16 / thread_n_blocks;
+  int iters = ceildiv(k_tiles * n_tiles * parallel, gridDim.x);
+  // Ensure that the number of tiles in each stripe is a multiple of the groupsize; this avoids an annoying special case
+  // where a stripe starts in the middle of group.
+  if (group_blocks != -1)
+    iters = (group_blocks / thread_k_blocks) * ceildiv(iters, (group_blocks / thread_k_blocks));
+
+  int slice_row = (iters * blockIdx.x) % k_tiles;
+  int slice_col_par = (iters * blockIdx.x) / k_tiles;
+  int slice_col = slice_col_par;
+  int slice_iters; // number of threadblock tiles in the current slice
+  int slice_count = 0; // total number of active threadblocks in the current slice
+  int slice_idx; // index of threadblock in current slice; numbered bottom to top
+
+  // We can easily implement parallel problem execution by just remapping indices and advancing global pointers
+  if (slice_col_par >= n_tiles) {
+    A += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_k / 8;
+    C += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_n / 8;
+    locks += (slice_col_par / n_tiles) * n_tiles;
+    slice_col = slice_col_par % n_tiles;
+  }
+
+  // Compute all information about the current slice which is required for synchronization.
+  auto init_slice = [&] () {
+    slice_iters = iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
+    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel)
+      slice_iters = 0;
+    if (slice_iters == 0)
+      return;
+    if (slice_row + slice_iters > k_tiles)
+      slice_iters = k_tiles - slice_row;
+    slice_count = 1;
+    slice_idx = 0;
+    int col_first = iters * ceildiv(k_tiles * slice_col_par, iters);
+    if (col_first <= k_tiles * (slice_col_par + 1)) {
+      int col_off = col_first - k_tiles * slice_col_par;
+      slice_count = ceildiv(k_tiles - col_off, iters);
+      if (col_off > 0)
+        slice_count++;
+      int delta_first = iters * blockIdx.x - col_first;
+      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
+        slice_idx = slice_count - 1;
+      else {
+        slice_idx = slice_count - 1 - delta_first / iters;
+        if (col_off > 0)
+          slice_idx--;
+      }
+    }
+    if (slice_col == n_tiles) {
+      A += 16 * thread_m_blocks * prob_k / 8;
+      C += 16 * thread_m_blocks * prob_n / 8;
+      locks += n_tiles;
+      slice_col = 0;
+    }
+  };
+  init_slice();
+
+  int a_gl_stride = prob_k / 8; // stride of the A matrix in global memory
+  // We typically use `constexpr` to indicate that this value is a compile-time constant
+  constexpr int a_sh_stride = 16 * thread_k_blocks / 8; // stride of an A matrix tile in shared memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / 8; // delta between subsequent A tiles in global memory
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o); // between subsequent accesses within a tile
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o); // between shared memory writes
+  constexpr int a_sh_rd_delta_o = 2 * ((threads / 32) / (thread_n_blocks / 4)); // between shared memory tile reads
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16; // within a shared memory tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks); // overall size of a tile
+  constexpr int a_sh_wr_iters = ceildiv(a_sh_stage, a_sh_wr_delta); // number of shared write iterations for a tile
+
+  int b_gl_stride = 16 * prob_n / 32;
+  constexpr int b_sh_stride = 32 * thread_n_blocks / 4;
+  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks;
+  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride);
+  constexpr int b_sh_wr_delta = threads;
+  constexpr int b_sh_rd_delta = threads;
+  constexpr int b_sh_stage = b_sh_stride * thread_k_blocks;
+  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
+
+  int s_gl_stride = prob_n / 8;
+  constexpr int s_sh_stride = 16 * thread_n_blocks / 8;
+  constexpr int s_sh_stage = s_sh_stride;
+  int s_gl_rd_delta = s_gl_stride;
+
+  // Global A read index of current thread.
+  int a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  a_gl_rd += a_gl_rd_delta_o * slice_row;
+  // Shared write index of current thread.
+  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  // Shared read index.
+  int a_sh_rd = a_sh_stride * ((threadIdx.x % 32) % 16) + (threadIdx.x % 32) / 16;
+  a_sh_rd += 2 * ((threadIdx.x / 32) / (thread_n_blocks / 4));
+
+  int b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+  b_gl_rd += b_sh_stride * slice_col;
+  b_gl_rd += b_gl_rd_delta_o * slice_row;
+  int b_sh_wr = threadIdx.x;
+  int b_sh_rd = threadIdx.x;
+
+  int s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
+  int s_sh_wr = threadIdx.x;
+  int s_sh_rd;
+  // We use a different scale layout for grouped and column-wise quantization as we scale a `half2` tile in column-major
+  // layout in the former and in row-major in the latter case.
+  if (group_blocks != -1)
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 4;
+  else
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) % 4;
+
+  // Precompute which thread should not read memory in which iterations; this is needed if there are more threads than
+  // required for a certain tilesize or when the batchsize is not a multiple of 16.
+  bool a_sh_wr_pred[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stride;
+
+  // To ensure that writing and reading A tiles to/from shared memory, the latter in fragment format, is fully bank
+  // conflict free, we need to use a rather fancy XOR-based layout. The key here is that neither reads nor writes of
+  // the 16-byte `int4` blocks of 8 consecutive threads involve the same shared memory banks. Further, it seems (based
+  // on NSight-Compute) that each warp must also write a consecutive memory segment?
+  auto transform_a = [&] (int i) {
+    int row = i / a_gl_rd_delta_o;
+    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ row;
+  };
+  // Since the computation of this remapping is non-trivial and, due to our main loop unrolls, all shared memory
+  // accesses are static, we simply precompute both transformed reads and writes.
+  int a_sh_wr_trans[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
+  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++) {
+    #pragma unroll
+    for (int j = 0; j < thread_m_blocks; j++)
+      a_sh_rd_trans[i][j] = transform_a(a_sh_rd_delta_o * i + a_sh_rd_delta_i * j + a_sh_rd);
+  }
+
+  // Since B-accesses have non-constant stride they have to be computed at runtime; we break dependicies between
+  // subsequent accesses with a tile by maintining multiple pointers (we have enough registers), a tiny optimization.
+  const int4* B_ptr[b_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++)
+    B_ptr[i] = B + b_gl_rd_delta_i * i + b_gl_rd;
+
+  extern __shared__ int4 sh[];
+  // Shared memory storage for global fetch pipelines.
+  int4* sh_a = sh;
+  int4* sh_b = sh_a + (stages * a_sh_stage);
+  int4* sh_s = sh_b + (stages * b_sh_stage);
+  // Register storage for double buffer of shared memory reads.
+  FragA frag_a[2][thread_m_blocks];
+  I4 frag_b_quant[2];
+  FragC frag_c[thread_m_blocks][4][2];
+  FragS frag_s[2][4];
+
+  // Zero accumulators.
+  auto zero_accums = [&] () {
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
+      reinterpret_cast<float*>(frag_c)[i] = 0;
+  };
+
+  // Asynchronously fetch the next A, B and s tile from global to the next shared memory pipeline location.
+  auto fetch_to_shared = [&] (int pipe, int a_off, bool pred = true) {
+    if (pred) {
+      int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < a_sh_wr_iters; i++) {
+        cp_async4_pred(
+          &sh_a_stage[a_sh_wr_trans[i]],
+          &A[a_gl_rd_delta_i * i + a_gl_rd + a_gl_rd_delta_o * a_off],
+          a_sh_wr_pred[i]
+        );
+      }
+      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < b_sh_wr_iters; i++) {
+        cp_async4_stream(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr], B_ptr[i]);
+        B_ptr[i] += b_gl_rd_delta_o;
+      }
+      // Only fetch scales if this tile starts a new group
+      if (group_blocks != -1 && pipe % (group_blocks / thread_k_blocks) == 0) {
+        int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
+        s_gl_rd += s_gl_rd_delta;
+      }
+    }
+    // Insert a fence even when we are winding down the pipeline to ensure that waiting is also correct at this point.
+    cp_async_fence();
+  };
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&] () {
+    // We only have `stages - 2` active fetches since we are double buffering and can only issue the next fetch when
+    // it is guaranteed that the previous shared memory load is fully complete (as it may otherwise be overwritten).
+    cp_async_wait<stages - 2>();
+    __syncthreads();
+  };
+
+  // Load the next sub-tile from the current location in the shared memory pipe into the current register buffer.
+  auto fetch_to_registers = [&] (int k, int pipe) {
+    // It may seem inefficient that we reload the groups for every sub-tile; however, this does not seem to be a
+    // significant bottleneck, while some theoretically better attempts have lead to bad instruction ordering by the
+    // compiler and correspondingly a noticable drop in performance.
+    if (group_blocks != -1) {
+      int4* sh_s_stage = sh_s + s_sh_stage * ((group_blocks / thread_k_blocks) * (pipe / (group_blocks / thread_k_blocks)));
+      reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+    }
+    int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks; i++)
+      ldsm4(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+    frag_b_quant[k % 2] = *reinterpret_cast<I4*>(&sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd]);
+  };
+
+  // Execute the actual tensor core matmul of a sub-tile.
+  auto matmul = [&] (int k) {
+    // We have the m dimension as the inner loop in order to encourage overlapping dequantization and matmul operations.
+    #pragma unroll
+    for (int j = 0; j < 4; j++) {
+      int b_quant = frag_b_quant[k % 2][j];
+      int b_quant_shift = b_quant >> 8;
+      FragB frag_b0 = dequant(b_quant);
+      // If there are no groups, we can just scale the final output once and can avoid doing so for each weight.
+      if (group_blocks != -1)
+        scale(frag_b0, frag_s[k % 2][j], 0);
+      FragB frag_b1 = dequant(b_quant_shift);
+      if (group_blocks != -1)
+        scale(frag_b1, frag_s[k % 2][j], 1);
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        mma(frag_a[k % 2][i], frag_b0, frag_c[i][j][0]);
+        mma(frag_a[k % 2][i], frag_b1, frag_c[i][j][1]);
+      }
+    }
+  };
+
+  // Since we slice across the k dimension of a tile in order to increase the number of warps while keeping the n
+  // dimension of a tile reasonable, we have multiple warps that accumulate their partial sums of the same output
+  // location; which we have to reduce over in the end. We do in shared memory.
+  auto thread_block_reduce = [&] () {
+    constexpr int red_off = threads / b_sh_stride / 2;
+    if (red_off >= 1) {
+      int red_idx = threadIdx.x / b_sh_stride;
+      constexpr int red_sh_stride = b_sh_stride * 4 * 2;
+      constexpr int red_sh_delta = b_sh_stride;
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+
+      // Parallel logarithmic shared memory reduction. We make sure to avoid any unnecessary read or write iterations,
+      // e.g., for two warps we write only once by warp 1 and read only once by warp 0.
+
+      #pragma unroll
+      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
+        #pragma unroll
+        for (int i = red_off; i > 0; i /= 2) {
+          if (i <= red_idx && red_idx < 2 * i) {
+            #pragma unroll
+            for (int j = 0; j < 4 * 2; j++) {
+              int red_sh_wr = red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
+              if (i < red_off) {
+                float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh[red_sh_wr]);
+                #pragma unroll
+                for (int k = 0; k < 4; k++)
+                  reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] += c_rd[k] + c_wr[k];
+              }
+              sh[red_sh_wr] = reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
+            }
+          }
+          __syncthreads();
+        }
+        if (red_idx == 0) {
+          #pragma unroll
+          for (int i = 0; i < 4 * 2; i++) {
+            float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * i + red_sh_rd]);
+            #pragma unroll
+            for (int j = 0; j < 4; j++)
+              reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] += c_rd[j];
+          }
+        }
+        __syncthreads();
+      }
+    }
+  };
+
+  // Since multiple threadblocks may process parts of the same column slice, we finally have to globally reduce over
+  // the results. As the striped partioning minimizes the number of such reductions and our outputs are usually rather
+  // small, we perform this reduction serially in L2 cache.
+  auto global_reduce = [&] (bool first = false, bool last = false) {
+    // We are very careful here to reduce directly in the output buffer to maximize L2 cache utilization in this step.
+    // To do this, we write out results in FP16 (but still reduce with FP32 compute).
+    constexpr int active_threads = 32 * thread_n_blocks / 4;
+    if (threadIdx.x < active_threads) {
+      int c_gl_stride = prob_n / 8;
+      int c_gl_wr_delta_o = 8 * c_gl_stride;
+      int c_gl_wr_delta_i = 4 * (active_threads / 32);
+      int c_gl_wr = c_gl_stride * ((threadIdx.x % 32) / 4) + 4 * (threadIdx.x / 32) + threadIdx.x % 4;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+      constexpr int c_sh_wr_delta = active_threads;
+      int c_sh_wr = threadIdx.x;
+
+      int row = (threadIdx.x % 32) / 4;
+
+      if (!first) {
+        // Interestingly, doing direct global accesses here really seems to mess up the compiler and lead to slowdowns,
+        // hence we also use async-copies even though these fetches are not actually asynchronous.
+        #pragma unroll
+        for (int i = 0; i < thread_m_blocks * 4; i++) {
+          cp_async4_pred(
+            &sh[c_sh_wr + c_sh_wr_delta * i],
+            &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)],
+            i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m
+          );
+        }
+        cp_async_fence();
+        cp_async_wait<0>();
+      }
+
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks * 4; i++) {
+        if (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) {
+          if (!first) {
+            int4 c_red = sh[c_sh_wr + i * c_sh_wr_delta];
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)] += __half2float(
+                reinterpret_cast<__half*>(&c_red)[j]
+              );
+            }
+          }
+          if (!last) {
+            int4 c;
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<__half*>(&c)[j] = __float2half(
+                reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)]
+              );
+            }
+            C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] = c;
+          }
+        }
+      }
+    }
+  };
+
+  // Write out the reduce final result in the correct layout. We only actually reshuffle matrix fragments in this step,
+  // the reduction above is performed in fragment layout.
+  auto write_result = [&] () {
+    int c_gl_stride = prob_n / 8;
+    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
+    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
+    constexpr int c_sh_rd_delta = c_sh_stride * (threads / (2 * thread_n_blocks));
+
+    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+    c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    int c_sh_wr = (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
+    c_sh_wr += 32 * (threadIdx.x / 32);
+    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+
+    int c_gl_wr_end = c_gl_stride * prob_m;
+
+    // We first reorder in shared memory to guarantee the most efficient final global write patterns
+    auto write = [&] (int idx, float c0, float c1, FragS& s) {
+      half2 res = __halves2half2(__float2half(c0), __float2half(c1));
+      if (group_blocks == -1) // for per-column quantization we finally apply the scale here
+        res = __hmul2(res, s[0]);
+      ((half2*) sh)[idx] = res;
+    };
+    if (threadIdx.x / 32 < thread_n_blocks / 4) {
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          int wr = c_sh_wr + 8 * j;
+          write(wr + (4 * c_sh_stride) * 0 + 0, frag_c[i][j][0][0], frag_c[i][j][0][1], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 8 + 0, frag_c[i][j][0][2], frag_c[i][j][0][3], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 0 + 4, frag_c[i][j][1][0], frag_c[i][j][1][1], frag_s[j / 2][2 * (j % 2) + 1]);
+          write(wr + (4 * c_sh_stride) * 8 + 4, frag_c[i][j][1][2], frag_c[i][j][1][3], frag_s[j / 2][2 * (j % 2) + 1]);
+        }
+        c_sh_wr += 16 * (4 * c_sh_stride);
+      }
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < ceildiv(16 * thread_m_blocks, threads / (2 * thread_n_blocks)); i++) {
+      if (c_gl_wr < c_gl_wr_end) {
+        C[c_gl_wr] = sh[c_sh_rd];
+        c_gl_wr += c_gl_wr_delta;
+        c_sh_rd += c_sh_rd_delta;
+      }
+    }
+  };
+
+  // Start global fetch and register load pipelines.
+  auto start_pipes = [&] () {
+    #pragma unroll
+    for (int i = 0; i < stages - 1; i++)
+      fetch_to_shared(i, i, i < slice_iters);
+    zero_accums();
+    wait_for_stage();
+    fetch_to_registers(0, 0);
+    a_gl_rd += a_gl_rd_delta_o * (stages - 1);
+  };
+  start_pipes();
+
+  // Main loop.
+  while (slice_iters) {
+    // We unroll over both the global fetch and the register load pipeline to ensure all shared memory accesses are
+    // static. Note that both pipelines have even length meaning that the next iteration will always start at index 0.
+    #pragma unroll
+    for (int pipe = 0; pipe < stages;) {
+      #pragma unroll
+      for (int k = 0; k < b_sh_wr_iters; k++) {
+        fetch_to_registers(k + 1, pipe % stages);
+        if (k == b_sh_wr_iters - 2) {
+          fetch_to_shared((pipe + stages - 1) % stages, pipe, slice_iters >= stages);
+          pipe++;
+          wait_for_stage();
+        }
+        matmul(k);
+      }
+      slice_iters--;
+      if (slice_iters == 0)
+        break;
+    }
+    a_gl_rd += a_gl_rd_delta_o * stages;
+
+    // Process results and, if necessary, proceed to the next column slice. While this pattern may not be the most
+    // readable, other ways of writing the loop seemed to noticeably worse performance after compliation.
+    if (slice_iters == 0) {
+      cp_async_wait<0>();
+      bool last = slice_idx == slice_count - 1;
+      // For per-column scales, we only fetch them here in the final step before write-out
+      if (group_blocks == -1 && last) {
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s[s_sh_wr], &s[s_gl_rd]);
+        cp_async_fence();
+      }
+      thread_block_reduce();
+      if (group_blocks == -1 && last) {
+        cp_async_wait<0>();
+        __syncthreads();
+        if (threadIdx.x / 32 < thread_n_blocks / 4) {
+          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+        }
+      }
+      if (slice_count > 1) { // only globally reduce if there is more than one block in a slice
+        barrier_acquire(&locks[slice_col], slice_idx);
+        global_reduce(slice_idx == 0, last);
+        barrier_release(&locks[slice_col], last);
+      }
+      if (last) // only the last block in a slice actually writes the result
+        write_result();
+      slice_row = 0;
+      slice_col_par++;
+      slice_col++;
+      init_slice();
+      if (slice_iters) {
+        a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+        #pragma unroll
+        for (int i = 0; i < b_sh_wr_iters; i++)
+          B_ptr[i] += b_sh_stride - b_gl_rd_delta_o * k_tiles;
+        if (slice_col == 0) {
+          #pragma unroll
+          for (int i = 0; i < b_sh_wr_iters; i++)
+            B_ptr[i] -= b_gl_stride;
+        }
+        s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+        start_pipes();
+      }
+    }
+  }
+}
+
+
+// 8 warps are a good choice since every SM has 4 schedulers and having more than 1 warp per schedule allows some more
+// latency hiding. At the same time, we want relatively few warps to have many registers per warp and small tiles.
+const int THREADS = 256;
+const int STAGES = 4; // 4 pipeline stages fit into shared memory
+const int SHARED_MEM = 96 * 1024; // max shared memory on compute capability 8.6 (< 8.0)
+
+#define CALL_IF(THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, GROUP_BLOCKS) \
+  else if ( \
+    thread_m_blocks == THREAD_M_BLOCKS && thread_n_blocks == THREAD_N_BLOCKS && thread_k_blocks == THREAD_K_BLOCKS && \
+    group_blocks == GROUP_BLOCKS \
+  ) { \
+    cudaFuncSetAttribute( \
+      Marlin<THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS>, \
+      cudaFuncAttributeMaxDynamicSharedMemorySize, \
+      SHARED_MEM \
+    ); \
+    Marlin< \
+      THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS \
+    ><<<blocks, THREADS, SHARED_MEM, stream>>>( \
+      A_ptr, B_ptr, C_ptr, s_ptr, \
+      prob_m, prob_n, prob_k, \
+      locks \
+    ); \
+  }
+
+const int ERR_PROB_SHAPE = 1;
+const int ERR_KERN_SHAPE = 2;
+
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 16
+) {
+  int tot_m = prob_m;
+  int tot_m_blocks = ceildiv(tot_m, 16);
+  int pad = 16 * tot_m_blocks - tot_m;
+
+  if (sms == -1)
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+  if (thread_k == -1 || thread_n == -1) {
+    if (prob_m <= 16) {
+      // For small batchizes, better partioning is slightly more important than better compute utilization
+      thread_k = 128;
+      thread_n = 128;
+    } else {
+      thread_k = 64;
+      thread_n = 256;
+    }
+  }
+
+  int thread_k_blocks = thread_k / 16;
+  int thread_n_blocks = thread_n / 16;
+  int group_blocks = (groupsize == -1) ? -1 : groupsize / 16;
+  int blocks = sms;
+
+  if (prob_n % thread_n != 0 || prob_k % thread_k != 0 || (group_blocks != -1 && prob_k % group_blocks != 0))
+    return ERR_PROB_SHAPE;
+  if (prob_m == 0 || prob_n == 0 || prob_k == 0)
+    return 0;
+
+  const int4* A_ptr = (const int4*) A;
+  const int4* B_ptr = (const int4*) B;
+  int4* C_ptr = (int4*) C;
+  const int4* s_ptr = (const int4*) s;
+
+  int cols = prob_n / thread_n;
+  int* locks = (int*) workspace;
+
+  int ret = 0;
+  for (int i = 0; i < tot_m_blocks; i += 4) {
+    int thread_m_blocks = tot_m_blocks - i;
+    prob_m = tot_m - 16 * i;
+    int par = 1;
+    if (thread_m_blocks > 4) {
+      // Note that parallel > 1 currently only works for inputs without any padding
+      par = (16 * thread_m_blocks - pad) / 64;
+      if (par > max_par)
+        par = max_par;
+      prob_m = 64 * par;
+      i += 4 * (par - 1);
+      thread_m_blocks = 4;
+    }
+
+    // For compilation speed, we only define the kernel configurations that have seemed useful (in terms of performance)
+    // in our testing, however many more are, in principle, possible.
+    if (false) {}
+    CALL_IF(1,  8,  8, -1)
+    CALL_IF(1,  8,  8,  8)
+    CALL_IF(1, 16,  4, -1)
+    CALL_IF(1, 16,  4,  8)
+    CALL_IF(2, 16,  4, -1)
+    CALL_IF(2, 16,  4,  8)
+    CALL_IF(3, 16,  4, -1)
+    CALL_IF(3, 16,  4,  8)
+    CALL_IF(4, 16,  4, -1)
+    CALL_IF(4, 16,  4,  8)
+    else
+      ret = ERR_KERN_SHAPE;
+
+    A_ptr += 16 * thread_m_blocks * (prob_k / 8) * par;
+    C_ptr += 16 * thread_m_blocks * (prob_n / 8) * par;
+  }
+
+  return ret;
+}
+
+
+#endif

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda_kernel.cuh
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda_kernel.cuh
@@ -20,6 +20,7 @@ int marlin_cuda(
   const void* B,
         void* C,
         void* s,
+        void* sz, // ADDED: add scaled zero point
   int prob_m,
   int prob_n,
   int prob_k,

--- a/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda_kernel.cuh
+++ b/optimum/quanto/library/extensions/cuda/marlin/marlin_cuda_kernel.cuh
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cuda_runtime.h>
+
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 16
+);

--- a/optimum/quanto/library/extensions/cuda/pybind_module.cpp
+++ b/optimum/quanto/library/extensions/cuda/pybind_module.cpp
@@ -18,8 +18,7 @@
 #include "unpack.h"
 #include "marlin/fp8_marlin.cuh"
 #include "marlin/gptq_marlin_repack.cuh"
-#include <pybind11/pybind11.h>
-#include <torch/library.h>
+#include "marlin/marlin_cuda.h"
 
 // !IMPORTANT! Some python objects such as dtype, device, are not mapped to C++ types,
 // and need to be explicitly converted using dedicated helpers before calling a C++ method.
@@ -33,5 +32,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("awq_v2_gemv_f16i4", &awq_v2_gemv_f16i4, "awq_v2_gemv_f16i4");
   m.def("gptq_marlin_repack", &gptq_marlin_repack, "gptq_marlin_repack");
   m.def("fp8_marlin_gemm", &fp8_marlin_gemm, "fp8_marlin_gemm");
+  m.def("marlin_gemm_f16i4", &mul, "marlin_gemm_f16i4");
   m.def("unpack", &unpack, "unpack");
 }

--- a/optimum/quanto/tensor/weights/marlin/__init__.py
+++ b/optimum/quanto/tensor/weights/marlin/__init__.py
@@ -1,2 +1,3 @@
 from .fp8 import *
 from .int4 import *
+from .permutations import *

--- a/optimum/quanto/tensor/weights/marlin/__init__.py
+++ b/optimum/quanto/tensor/weights/marlin/__init__.py
@@ -1,1 +1,2 @@
 from .fp8 import *
+from .int4 import *

--- a/optimum/quanto/tensor/weights/marlin/int4/__init__.py
+++ b/optimum/quanto/tensor/weights/marlin/int4/__init__.py
@@ -1,0 +1,1 @@
+from .packed import *

--- a/optimum/quanto/tensor/weights/marlin/int4/__init__.py
+++ b/optimum/quanto/tensor/weights/marlin/int4/__init__.py
@@ -1,1 +1,2 @@
 from .packed import *
+from .qbits import *

--- a/optimum/quanto/tensor/weights/marlin/int4/packed.py
+++ b/optimum/quanto/tensor/weights/marlin/int4/packed.py
@@ -1,0 +1,160 @@
+import ast
+from copy import copy
+
+import numpy as np
+import torch
+from torch.utils import _pytree as pytree
+
+from ...packing import unpack_int32_to_uint8
+from ...reordering import reorder, reverse
+
+
+__all__ = ["MarlinInt4PackedTensor"]
+
+
+# From: https://github.com/IST-DASLab/marlin/blob/master/marlin/__init__.py#L40
+# this func does 2 things
+# 1. 1 thread can load 32 4bit == 128bit weights used for mulitple mma instructions at once
+# 2. faster dequant via parallel half2 mul
+def _get_perm():
+    perm = []
+    # 32 == # of threads in 1 warp
+    for i in range(32):
+        perm1 = []
+        # column id in 16x8 weight block
+        # check https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-fragment-mma-16816-float
+        col = i // 4
+        # 1 32bit (int32) == 8 4bit, 1 thread has 4 weights per 16x8 & 4bit weights are packed in int32, so needs 2 16x8 == 1 16x16 blocks
+        for block in [0, 1]:
+            # row id in 16x8 weight block
+            # check https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-fragment-mma-16816-float
+            for row in [
+                2 * (i % 4),
+                2 * (i % 4) + 1,
+                2 * (i % 4 + 4),
+                2 * (i % 4 + 4) + 1,
+            ]:
+                # 8 weights used for 1 thread (16x16 block) are contiguous in memory via interleaving
+                # e.g. T0 uses (0, 16, 128, 144, 8, 24, 136, 152)
+                perm1.append(16 * row + col + 8 * block)
+        # 1 128bit (int4) == 4 32bit, 1 thread loads 128bit at once, so needs 4 16x16 == 1 16x64 blocks
+        for j in range(4):
+            # 32 weights loaded by 1 thread (16x64 block) are contiguous in memory via interleaving
+            # e.g. T0 uses ((0 ~ 152) + 0 * 256, (0 ~ 152) + 1 * 256, ..., (0 ~ 152) + 3 * 256)
+            perm.extend([p + 256 * j for p in perm1])
+    perm = np.array(perm)
+    # for faster dequant
+    # check https://arxiv.org/pdf/2211.10017
+    interleave = np.array([0, 2, 4, 6, 1, 3, 5, 7])
+    perm = perm.reshape((-1, 8))[:, interleave].ravel()
+    perm = torch.from_numpy(perm)
+    return perm
+
+
+_perm = _get_perm()
+_rev_perm = reverse(_perm)
+
+
+# From: https://github.com/IST-DASLab/marlin/blob/master/marlin/__init__.py#L102
+def pack(unpacked: torch.Tensor):
+    w = unpacked
+    N, K = w.shape
+    w = unpacked.t()
+    # 16 == tile size, marlin uses 16x16 tile, so 16x16 grouping via interleaving
+    w = w.reshape((K // 16, 16, N // 16, 16))
+    w = w.permute((0, 2, 1, 3))
+    w = w.reshape((K // 16, N * 16))
+    res = w
+    # _perm.numel() == 1024 == 4 16x16, permute weights with 4 16x16 unit for efficient mma + dequant
+    res = res.reshape((-1, _perm.numel()))[:, _perm].reshape(res.shape)
+    p = np.zeros((res.shape[0], res.shape[1] // 8), dtype=np.uint32)
+    res = res.cpu().numpy().astype(np.uint32)
+    for i in range(8):
+        p |= res[:, i::8] << 4 * i
+    p = torch.from_numpy(p.astype(np.int32)).to(w.device)
+    return p
+
+
+def unpack(packed, orig_shape):
+    N, K = orig_shape
+    # Unpack to recover individual values
+    unpacked = unpack_int32_to_uint8(packed, bits=4).to(torch.uint8)
+    # Recover the original ordering
+    unpacked = reorder(unpacked, _rev_perm)
+    # Apply block permutations in the reverse order
+    unpacked = unpacked.reshape(K // 16, N // 16, 16, 16)
+    unpacked = unpacked.permute((0, 2, 1, 3))
+    unpacked = unpacked.reshape(K, N)
+    return unpacked.t()
+
+
+class MarlinInt4PackedTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, data, size, stride, requires_grad=False):
+        assert data.device.type == "cuda"
+        assert data.dtype == torch.int32
+        assert requires_grad is False
+        return torch.Tensor._make_wrapper_subclass(
+            cls, size, strides=stride, dtype=torch.uint8, device=data.device, requires_grad=requires_grad
+        )
+
+    def __init__(self, data, size, stride, requires_grad=False):
+        self._data = data
+
+    def __repr__(self):
+        return f"MarlinInt4PackedTensor({self._data})"
+
+    @classmethod
+    def pack(cls, t):
+        data = pack(t)
+        return MarlinInt4PackedTensor(data, t.size(), t.stride())
+
+    def unpack(self):
+        return unpack(self._data, self.size())
+
+    @property
+    def dtype(self):
+        return torch.uint8
+
+    def __tensor_flatten__(self):
+        inner_tensors = ["_data"]
+        meta = {
+            "size": str(list(self.size())),
+            "stride": str(self.stride()),
+        }
+        return inner_tensors, meta
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        assert len(inner_tensors) == 1
+        assert len(meta) == 2
+        data = inner_tensors["_data"]
+        size = ast.literal_eval(meta["size"])
+        stride = ast.literal_eval(meta["stride"])
+        return MarlinInt4PackedTensor(data, size, stride)
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, op, types, args, kwargs=None):
+        if op.overloadpacket is torch.ops.aten.detach:
+            t = args[0]
+            data = op(t._data)
+            return MarlinInt4PackedTensor(data, t.size(), t.stride())
+        elif op.overloadpacket in (torch.ops.aten._to_copy, torch.ops.aten.to):
+            t = args[0]
+            dtype = kwargs.get("dtype", torch.uint8)
+            if dtype != torch.uint8:
+                raise ValueError(f"MarlinInt4PackedTensor are torch.uint8 only and cannot be moved to {dtype}.")
+            device = kwargs.get("device", t.device)
+            if device.type == "cuda":
+                data_kwargs = copy(kwargs)
+                data_kwargs["dtype"] = t._data.dtype
+                data = op(t._data, **data_kwargs)
+                return MarlinInt4PackedTensor(data, t.size(), t.stride())
+            return t.unpack()
+        args, kwargs = pytree.tree_map_only(MarlinInt4PackedTensor, lambda x: x.unpack(), (args, kwargs or {}))
+        return op(*args, **kwargs)
+
+    def numpy(self):
+        return self.unpack().cpu().numpy()

--- a/optimum/quanto/tensor/weights/marlin/int4/qbits.py
+++ b/optimum/quanto/tensor/weights/marlin/int4/qbits.py
@@ -1,0 +1,168 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+
+import torch
+from torch.autograd import Function
+
+from ....function import QuantizedLinearFunction
+from ....grouped import group, ungroup
+from ....qtype import qtypes
+from ...qbits import WeightQBitsTensor
+from ..permutations import marlin_permute
+from .packed import MarlinInt4PackedTensor
+
+
+__all__ = ["MarlinInt4WeightQBitsTensor"]
+
+
+class MarlinQBitsDequantizer(Function):
+    @staticmethod
+    def forward(ctx, t):
+        unpacked = t._data.unpack()
+        scale = t._scale
+        shift = t._shift
+        unpacked = group(unpacked, axis=0, group_size=t._group_size)
+        # Apply inverted permutations
+        scale = marlin_permute(scale, reverse=True)
+        shift = marlin_permute(shift, reverse=True)
+        n_scales = scale.numel()
+        scale = scale.t().reshape((n_scales, 1))
+        shift = shift.t().reshape((n_scales, 1))
+        # Shift is already scaled and negated
+        dqt = scale * unpacked + shift
+        return ungroup(dqt, axis=t.axis, orig_shape=t.shape)
+
+    @staticmethod
+    def backward(ctx, gO):
+        return gO
+
+
+class MarlinQBitsLinearFunction(QuantizedLinearFunction):
+    @staticmethod
+    def forward(ctx, input, other, bias):
+        ctx.save_for_backward(input, other)
+        if type(input) is not torch.Tensor:
+            input = input.dequantize()
+        out_features, in_features = other.shape
+        output = torch.ops.quanto.gemm_f16i4_marlin(
+            input,
+            other._data._data,
+            other._scale,
+            other._shift,
+            other._workspace,
+        )
+        if bias is not None:
+            output = output + bias
+        return output
+
+
+class MarlinInt4WeightQBitsTensor(WeightQBitsTensor):
+    @staticmethod
+    def __new__(cls, qtype, axis, group_size, size, stride, data, scale, shift, requires_grad=False):
+        assert data.device.type == "cuda"
+        assert data.device == scale.device
+        assert data.device == shift.device
+        return torch.Tensor._make_wrapper_subclass(
+            cls, size, strides=stride, dtype=scale.dtype, device=data.device, requires_grad=requires_grad
+        )
+
+    def __init__(self, qtype, axis, group_size, size, stride, data, scale, shift, requires_grad=False):
+        assert axis == 0
+        out_features, in_features = size
+        if not isinstance(data, MarlinInt4PackedTensor):
+            assert type(data) is torch.Tensor
+            # Format data, scale and shift for optimized CUDA gemm
+            ungrouped = ungroup(data, axis=0, orig_shape=size)
+            data = MarlinInt4PackedTensor.pack(ungrouped)
+            scale = scale.reshape(out_features, in_features // group_size).t().contiguous()
+            shift = shift.reshape(out_features, in_features // group_size).t()
+            if not shift.dtype.is_floating_point:
+                # Integer shift must be scaled
+                shift = scale * shift
+            # Shift must be negated
+            shift = -shift.contiguous()
+            # Finally, apply scale and shift permutations
+            scale = marlin_permute(scale)
+            shift = marlin_permute(shift)
+        super().__init__(qtype, axis, group_size, size, stride, data, scale, shift)
+        self._workspace = torch.zeros(out_features // 128 * 16, dtype=torch.int, device=data.device)
+
+    def dequantize(self):
+        return MarlinQBitsDequantizer.apply(self)
+
+    def weight_qbits_tensor(self):
+        """Convert back to a WeightQBitsTensor
+
+        This is required to make sure only standard packing is used when serializing.
+        """
+        data = group(self._data.unpack(), axis=self.axis, group_size=self._group_size)
+        scale = marlin_permute(self._scale, reverse=True)
+        shift = marlin_permute(self._shift, reverse=True)
+        n_scales = scale.numel()
+        scale = scale.t().reshape((n_scales, 1))
+        shift = -shift.t().reshape((n_scales, 1))
+        return WeightQBitsTensor(
+            self._qtype, self._axis, self._group_size, self.size(), self.stride(), data, scale, shift
+        )
+
+    def __tensor_flatten__(self):
+        inner_tensors = ["_data", "_scale", "_shift"]
+        # Since meta can be used for serialization, use only strings
+        meta = {
+            "qtype": self._qtype.name,
+            "axis": str(self._axis),
+            "group_size": str(self._group_size),
+            "size": str(list(self.size())),
+            "stride": str(list(self.stride())),
+        }
+        return inner_tensors, meta
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        assert len(inner_tensors) == 3
+        assert len(meta) == 5
+        data, scale, shift = inner_tensors["_data"], inner_tensors["_scale"], inner_tensors["_shift"]
+        # Meta should only contain strings, AST compatible except qtype
+        qtype = qtypes[meta["qtype"]]
+        axis = ast.literal_eval(meta["axis"])
+        group_size = ast.literal_eval(meta["group_size"])
+        size = ast.literal_eval(meta["size"])
+        stride = ast.literal_eval(meta["stride"])
+        return MarlinInt4WeightQBitsTensor(qtype, axis, group_size, size, stride, data, scale, shift)
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        """Dispatch torch functions applied on this subtensor
+
+        This method is called whenever a torch function (such as `torch.nn.functional.linear`)
+        is called with at least one parameter coresponding to this subtensor:
+
+        - if a quantized implementation exists for the selected function, it is called,
+        - otherwise, the original implementation is called, deactivating further functional dispatch.
+
+        During the execution of the standard torch function, a second-level of dispatch will
+        happen, but this time directly on individual torch Tensor operations (mainly ATEN).
+        """
+        kwargs = kwargs or {}
+        if func is torch.nn.functional.linear:
+
+            def qlinear(input, other, bias=None):
+                return MarlinQBitsLinearFunction.apply(input, other, bias)
+
+            return qlinear(*args, **kwargs)
+        # Defer to operations dispatcher
+        with torch._C.DisableTorchFunctionSubclass():
+            return func(*args, **kwargs)

--- a/optimum/quanto/tensor/weights/marlin/permutations.py
+++ b/optimum/quanto/tensor/weights/marlin/permutations.py
@@ -1,0 +1,51 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from typing import List, Tuple
+
+import torch
+
+from ..reordering import reorder, reverse
+
+
+__all__ = ["marlin_permute"]
+
+
+# https://github.com/IST-DASLab/marlin/blob/2f6d7c10e124b3c5fa29ff8d77d568bd7af3274c/marlin/__init__.py#L40C1-L68C54
+@functools.cache
+def _get_perms() -> Tuple[List[int], List[int]]:
+    perm = []
+    for i in range(8):
+        perm.extend([i + 8 * j for j in range(8)])
+    perm_single = []
+    for i in range(4):
+        perm_single.extend([2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
+    return perm, perm_single
+
+
+@functools.cache
+def _get_inverted_perms() -> Tuple[List[int], List[int]]:
+    perm, perm_single = _get_perms()
+    return reverse(perm), reverse(perm_single)
+
+
+def marlin_permute(t: torch.Tensor, reverse=False):
+    perm, perm_single = _get_inverted_perms() if reverse else _get_perms()
+    out_features = t.shape[1]
+    if t.shape[0] == 1:
+        reordered = reorder(t, perm_single)
+    else:
+        reordered = reorder(t, perm)
+    return reordered.reshape((-1, out_features)).contiguous()

--- a/test/library/test_mm.py
+++ b/test/library/test_mm.py
@@ -18,7 +18,9 @@ import torch
 from helpers import assert_similar, random_tensor
 
 from optimum.quanto.tensor.weights.awq import AWQPackedTensor, AWQPacking
+from optimum.quanto.tensor.weights.marlin import marlin_permute
 from optimum.quanto.tensor.weights.marlin.fp8.packed import get_scale_perms, pack_fp8_as_int32
+from optimum.quanto.tensor.weights.marlin.int4.packed import MarlinInt4PackedTensor
 
 
 @pytest.mark.parametrize("batch_size", [1, 10, None], ids=["single", "batched", "static"])
@@ -139,3 +141,48 @@ def test_fp8_marlin(tokens, in_features, out_features, dtype):
     pt_outputs = torch.matmul(inputs.to(dtype), other)
     # Verify the results are similar
     assert_similar(lib_outputs, pt_outputs)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 8,
+    reason="CUDA device >= sm80 not available",
+)
+@pytest.mark.parametrize("in_features, out_features", [(256, 256), (512, 256)])
+@pytest.mark.parametrize("batch_size, tokens", [(1, 16), (10, 128)], ids=["small", "medium"])
+def test_gemm_marlin_fp16_int4(batch_size, tokens, in_features, out_features):
+    bits = 4
+    group_size = 128  # Hard-coded in kernels
+    device = torch.device("cuda")
+    input_shape = (batch_size, tokens, in_features)
+    # FIXME: does not work if inputs are negative !!??
+    inputs = torch.rand(input_shape, dtype=torch.float16, device=device)
+    qmax = 2**bits
+    other_shape = (out_features, in_features)
+    other_data = torch.randint(0, qmax, other_shape, dtype=torch.uint8, device=device)
+    # The GEMM kernel works on transposed scales
+    scales_shape = (in_features // group_size, out_features)
+    other_scales = torch.rand(scales_shape, dtype=torch.float16, device=device) / qmax
+    # This kernel works on transposed, negated and scaled zeropoints
+    qmin = -(2 ** (bits - 1))
+    qmax = 2 ** (bits - 1)
+    other_shifts = torch.randint(qmin, qmax, scales_shape, dtype=torch.int8, device=device)
+    # Negate and scale
+    other_scaled_shifts = -other_shifts * other_scales
+    workspace = torch.zeros(out_features // 128 * 16, dtype=torch.int, device=inputs.device)
+    packed_other_data_marlin = MarlinInt4PackedTensor.pack(other_data)._data
+    # Apply scale and shift permutations
+    other_scales_marlin = marlin_permute(other_scales)
+    other_scaled_shifts_marlin = marlin_permute(other_scaled_shifts)
+    lib_outputs = torch.ops.quanto.gemm_f16i4_marlin(
+        inputs, packed_other_data_marlin, other_scales_marlin, other_scaled_shifts_marlin, workspace
+    )
+    # Transpose other data and reshape it to align it with transposed scales and zeros
+    other_data_t = other_data.t().reshape(group_size, in_features // group_size, out_features)
+    # Dequantize transposed other
+    other_t = other_data_t * other_scales + other_scaled_shifts
+    # Reshape it as expected by the matmul
+    other_t = other_t.reshape(in_features, out_features)
+    # Evaluate the matrix multiplication using pytorch float16 mm
+    pt_outputs = torch.matmul(inputs, other_t)
+    # Verify the results are similar
+    assert_similar(lib_outputs, pt_outputs, rtol=1e-3)

--- a/test/tensor/weights/optimized/test_marlin_int4_packed_tensor.py
+++ b/test/tensor/weights/optimized/test_marlin_int4_packed_tensor.py
@@ -1,0 +1,60 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pytest
+import torch
+from helpers import device_eq
+
+from optimum.quanto.tensor.weights.marlin.int4 import MarlinInt4PackedTensor
+
+
+def get_uint4_tensor(shape, device, random=False):
+    qmax = 2**4
+    if random:
+        t = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    else:
+        numel = np.prod(shape)
+        t = torch.tensor(range(numel), dtype=torch.int32)
+        t = (t % qmax).reshape(shape).to(torch.uint8).to(device)
+    return t
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("random", [True, False])
+def test_pack_marlin_int4_tensor(in_features, out_features, random):
+    shape = (out_features, in_features)
+    device = torch.device("cuda")
+    t = get_uint4_tensor(shape, device, random)
+    packed = MarlinInt4PackedTensor.pack(t)
+    assert isinstance(packed, MarlinInt4PackedTensor)
+    assert device_eq(packed.device, device)
+    assert torch.equal(t, packed.unpack())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_move_marlin_int4_packed_tensor(device):
+    shape = (256, 256)
+    device = torch.device("cuda")
+    t = get_uint4_tensor(shape, device)
+    packed = MarlinInt4PackedTensor.pack(t)
+    moved = packed.to("cuda")
+    assert isinstance(moved, MarlinInt4PackedTensor)
+    # Marlin int4 tensors are unpacked when moved out of CUDA device
+    moved = packed.to("cpu")
+    assert type(moved) is torch.Tensor
+    assert torch.equal(t, moved.to("cuda"))

--- a/test/tensor/weights/optimized/test_marlin_int4_weight_qbits_tensor.py
+++ b/test/tensor/weights/optimized/test_marlin_int4_weight_qbits_tensor.py
@@ -1,0 +1,120 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from helpers import assert_similar, device_eq, random_qweight, random_tensor
+
+from optimum.quanto import qint4
+from optimum.quanto.tensor.weights import WeightQBitsTensor
+from optimum.quanto.tensor.weights.marlin.int4 import MarlinInt4WeightQBitsTensor
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 8, reason="CUDA >= sm80 not available"
+)
+@pytest.mark.parametrize("in_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
+def test_marlin_int4_weight_qbits_tensor_from_qbits_tensor(in_features, out_features):
+    qtype = qint4
+    group_size = 128
+    dtype = torch.float16
+    shape = (out_features, in_features)
+    device = torch.device("cuda")
+    qbt = random_qweight(shape, qtype, dtype, group_size=group_size, device=device)
+    # Create a MarlinInt4WeightQBitsTensor from the WeightQBitsTensor members
+    marlinqbt = MarlinInt4WeightQBitsTensor(
+        qtype=qbt.qtype,
+        axis=qbt.axis,
+        group_size=qbt._group_size,
+        size=qbt.size(),
+        stride=qbt.stride(),
+        data=qbt._data.unpack(),
+        scale=qbt._scale,
+        shift=qbt._shift,
+    )
+    assert marlinqbt.dtype == dtype
+    assert marlinqbt.qtype == qtype
+    assert marlinqbt.shape == shape
+    assert device_eq(marlinqbt.device, device)
+    # Verify the dequantized tensors are identical
+    assert torch.equal(marlinqbt.dequantize(), qbt.dequantize())
+    # Now verify that we can reconstruct the WeightQBitsTensor
+    new_qbt = marlinqbt.weight_qbits_tensor()
+    assert type(new_qbt) is WeightQBitsTensor
+    assert new_qbt.dtype == dtype
+    assert new_qbt.qtype == qtype
+    assert new_qbt.shape == shape
+    assert torch.equal(new_qbt._data, qbt._data)
+    assert torch.equal(new_qbt._scale, qbt._scale)
+    assert torch.equal(new_qbt._shift, qbt._shift)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_marlin_int4_weight_qbits_tensor_move(device):
+    qtype = qint4
+    group_size = 128
+    dtype = torch.float16
+    shape = (1024, 1024)
+    device = torch.device("cuda")
+    # Create an MarlinInt4WeightQBitsTensor from a QBitsTensor on CUDA
+    qbt = random_qweight(shape, qtype, dtype, group_size=group_size, device=torch.device("cuda"))
+    marlinqbt = MarlinInt4WeightQBitsTensor(
+        qtype=qbt.qtype,
+        axis=qbt.axis,
+        group_size=qbt._group_size,
+        size=qbt.size(),
+        stride=qbt.stride(),
+        data=qbt._data.unpack(),
+        scale=qbt._scale,
+        shift=qbt._shift,
+    )
+    # Move to device, dequantize and compare
+    moved_qbt = marlinqbt.to(device)
+    assert isinstance(moved_qbt, WeightQBitsTensor)
+    if device.type != "cuda":
+        assert type(moved_qbt) is not MarlinInt4WeightQBitsTensor
+    assert marlinqbt.dtype == moved_qbt.dtype
+    assert marlinqbt.qtype == moved_qbt.qtype
+    assert marlinqbt.shape == moved_qbt.shape
+    assert torch.equal(marlinqbt.dequantize().to(device), moved_qbt.dequantize())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens", [256, 512])
+@pytest.mark.parametrize("embeddings", [256, 512, 1024, 4096])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+def test_marlin_int4_weight_qbits_tensor_linear(batch_size, tokens, embeddings, use_bias):
+    device = torch.device("cuda")
+    dtype = torch.float16
+    weight_qtype = qint4
+    group_size = 128
+    inputs = torch.rand((batch_size,) + (tokens, embeddings), dtype=dtype, device=device)
+    # Create an MarlinInt4WeightQBitsTensor from a QBitsTensor on CUDA
+    qbt = random_qweight((tokens, embeddings), weight_qtype, dtype, group_size=group_size, device=torch.device("cuda"))
+    marlin_qweight = MarlinInt4WeightQBitsTensor(
+        qtype=qbt.qtype,
+        axis=qbt.axis,
+        group_size=qbt._group_size,
+        size=qbt.size(),
+        stride=qbt.stride(),
+        data=qbt._data.unpack(),
+        scale=qbt._scale,
+        shift=qbt._shift,
+    )
+    bias = random_tensor((tokens,), dtype=dtype).to(device) if use_bias else None
+    qout = torch.nn.functional.linear(inputs, marlin_qweight, bias)
+    out = torch.nn.functional.linear(inputs, qbt.dequantize(), bias)
+    assert_similar(out, qout)


### PR DESCRIPTION
# What does this PR do?

This adds a modified Marlin `fp16`/`int4` kernel to the library and creates two new `QTensor` subclasses to use it:

- `MarlinInt4PackedTensor`,
- `MarlinInt4WeightQBitsTensor`.

The AWQ kernel is still used by default because from the first tests it seems the modified Marlin kernel either has some accuracy issues or is not properly integrated (perplexity increases).

Note: during the integration, I tried to register the Marlin fp16int4 gemm as a `torch.tensor.library.custom_op`, but it added an extra latency (up to 50 %), so I used the same legacy declaration (with `define`/`impl`).