### PR TITLE
chore: minimal python version is 3.9

### DIFF
--- a/.github/workflows/linux-cpu-tests.yml
+++ b/.github/workflows/linux-cpu-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,13 @@ classifiers = [
     'Intended Audience :: Education',
     'Intended Audience :: Science/Research',
     'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering :: Artificial Intelligence'
 ]
 keywords = ['torch', 'quantization']
-requires-python = '>=3.8.0'
+requires-python = '>=3.9.0'
 authors = [{ name = 'David Corvoysier' }]
 maintainers = [
     {name = "HuggingFace Inc. Special Ops Team", email="hardware@huggingface.co"},


### PR DESCRIPTION
# What does this PR do?

This bump the minimum python version to 3.9.