### PR TITLE
Stricter optimized tensor tests

### DIFF
--- a/optimum/quanto/tensor/weights/quantization.py
+++ b/optimum/quanto/tensor/weights/quantization.py
@@ -32,6 +32,7 @@ def quantize_weight(
     shift: Optional[torch.Tensor] = None,
     group_size: Optional[int] = None,
     activation_qtype: Optional[qtype] = None,
+    optimized: Optional[bool] = True,
 ):
     """Quantize a weight Tensor.
 
@@ -48,7 +49,11 @@ def quantize_weight(
             Which quantization type is being used for the activations. The function `quantize_weight`
             initializes `torch.Tensor` subclasses that may depend on the activation dtype.
             `None` corresponds to no quantization.
-
+        optimized (`Optional[bool]`, defaults to True):
+            If True, the quantization algorithm will select the most efficient kernel
+            for the weights and format the resulting Tensor accordingly.
+            If False, a kernel-agnostic Tensor will be returned (but it can be optimized later
+            explicitly by calling QTensor.optimize() or implicitly by moving it to a specific device).
     Returns:
         A quantized Tensor.
     """
@@ -62,7 +67,7 @@ def quantize_weight(
         if axis is not None and t.shape[axis] == 1:
             # Quantizing along an axis of dimension 1 means quantizing per-tensor
             axis = None
-        return WeightQBytesTensor.quantize(t, qtype, axis, scale, activation_qtype)
+        return WeightQBytesTensor.quantize(t, qtype, axis, scale, activation_qtype, optimized)
     if shift is None:
         raise ValueError("shift must be specified for qtypes lower than 8-bit")
-    return WeightQBitsTensor.quantize(t, qtype, axis, group_size, scale, shift)
+    return WeightQBitsTensor.quantize(t, qtype, axis, group_size, scale, shift, optimized)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -69,7 +69,11 @@ def random_qactivation(shape, qtype=qint8, dtype=torch.float32, device="cpu"):
 
 
 def random_qweight(shape, qtype, dtype=torch.float32, axis=0, group_size=None, device="cpu"):
+    # Instantiate a random tensor in the range [-1, 1]
     t = random_tensor(shape, dtype, device=device)
+    # Divide by the square of the reduction dim k to avoid overflows and nans during accumulation
+    k = t.shape[-1 if axis == 0 else 0]
+    t = t / (k**2)
     if qtype.bits == 8:
         scale = AbsmaxOptimizer()(t, qtype=qtype, axis=axis)
         shift = None

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -28,7 +28,6 @@ from optimum.quanto import (
     quantize_activation,
     quantize_weight,
 )
-from optimum.quanto.tensor.weights import WeightQBitsTensor
 
 
 def torch_min_version(v):
@@ -76,23 +75,7 @@ def random_qweight(shape, qtype, dtype=torch.float32, axis=0, group_size=None, d
         shift = None
     else:
         scale, shift = MaxOptimizer()(t, qtype=qtype, axis=axis, group_size=group_size)
-    return quantize_weight(t, qtype=qtype, axis=axis, scale=scale, shift=shift, group_size=group_size)
-
-
-def random_weight_qbits_tensor(shape, qtype, dtype, group_size, device):
-    bits = qtype.bits
-    qmax = 2**bits
-    out_features, in_features = shape
-    n_scales = out_features * in_features // group_size
-    data_shape = (n_scales, group_size)
-    data = torch.randint(0, qmax, data_shape, dtype=torch.uint8, device=device)
-    scale_shape = (n_scales, 1)
-    scale = torch.rand(scale_shape, dtype=dtype, device=device) / qmax
-    shift_shape = (n_scales, 1)
-    shift = torch.rand(shift_shape, dtype=dtype, device=device)
-    return WeightQBitsTensor(
-        qtype, axis=0, group_size=group_size, size=shape, stride=(in_features, 1), data=data, scale=scale, shift=shift
-    )
+    return quantize_weight(t, qtype=qtype, axis=axis, scale=scale, shift=shift, group_size=group_size, optimized=False)
 
 
 def assert_similar(a, b, atol=None, rtol=None):

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -90,7 +90,7 @@ def test_quantize_linear_float32_activations_int8(batch_size, tokens, embeddings
 def test_quantize_linear_float16_activations_float8(
     batch_size, tokens, embeddings, use_bias, dtype, weights, activations, device
 ):
-    atol = 1e-4
+    atol = 5e-3
     _test_quantize_linear(batch_size, tokens, embeddings, use_bias, weights, activations, dtype, device, atol)
 
 

--- a/test/tensor/weights/optimized/test_awq_weight_qbits_tensor.py
+++ b/test/tensor/weights/optimized/test_awq_weight_qbits_tensor.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from helpers import assert_similar, device_eq, random_tensor, random_weight_qbits_tensor
+from helpers import assert_similar, device_eq, random_qweight, random_tensor
 
 from optimum.quanto import qint4
 from optimum.quanto.tensor.weights import WeightQBitsTensor
@@ -32,7 +32,7 @@ def test_awq_weight_qbits_tensor_from_qbits_tensor(in_features, out_features):
     dtype = torch.float16
     shape = (out_features, in_features)
     device = torch.device("cuda")
-    qbt = random_weight_qbits_tensor(shape, qtype, dtype, group_size, device)
+    qbt = random_qweight(shape, qtype, dtype, group_size=group_size, device=device)
     # Create a AWQWeightQBitsTensor from the WeightQBitsTensor members
     awqbt = AWQWeightQBitsTensor(
         qtype=qbt.qtype,
@@ -69,7 +69,7 @@ def test_awq_weight_qbits_tensor_move(device):
     shape = (1024, 1024)
     device = torch.device("cuda")
     # Create an AWQWeightQBitsTensor from a QBitsTensor on CUDA
-    qbt = random_weight_qbits_tensor(shape, qtype, dtype, group_size, device=torch.device("cuda"))
+    qbt = random_qweight(shape, qtype, dtype, group_size=group_size, device=torch.device("cuda"))
     awqbt = AWQWeightQBitsTensor(
         qtype=qbt.qtype,
         axis=qbt.axis,
@@ -102,8 +102,8 @@ def test_awq_weight_qbits_tensor_linear(batch_size, tokens, embeddings, use_bias
     group_size = 128
     inputs = torch.rand((batch_size,) + (tokens, embeddings), dtype=dtype, device=device)
     # Create an AWQWeightQBitsTensor from a QBitsTensor on CUDA
-    qbt = random_weight_qbits_tensor(
-        (embeddings, embeddings), weight_qtype, dtype, group_size, device=torch.device("cuda")
+    qbt = random_qweight(
+        (embeddings, embeddings), weight_qtype, dtype, group_size=group_size, device=torch.device("cuda")
     )
     awq_qweight = AWQWeightQBitsTensor(
         qtype=qbt.qtype,

--- a/test/tensor/weights/optimized/test_tinygemm_weight_qbits_tensor.py
+++ b/test/tensor/weights/optimized/test_tinygemm_weight_qbits_tensor.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from helpers import assert_similar, device_eq, random_qweight
+from helpers import assert_similar, device_eq, random_qweight, random_tensor
 from packaging import version
 
 from optimum.quanto import qint4
@@ -89,3 +89,35 @@ def test_tinygemm_weight_qbits_tensor_move(device):
     assert tgqbt.qtype == tgqbt_cpu.qtype
     assert tgqbt.shape == tgqbt_cpu.shape
     assert torch.equal(tgqbt.dequantize().cpu(), tgqbt_cpu.dequantize())
+
+
+@pytest.mark.skip_device("mps")  # Only available with pytorch 2.4
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens", [256, 512])
+@pytest.mark.parametrize("embeddings", [256, 512, 1024, 4096])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+def test_tinygemm_weight_qbits_tensor_linear(batch_size, tokens, embeddings, use_bias, device):
+    if device.type == "cuda":
+        if version.parse(torch.version.cuda).release < (12, 1):
+            pytest.skip(reason="CUDA runtime must be at least 12.1")
+        if torch.cuda.get_device_capability()[0] < 8:
+            pytest.skip(reason="CUDA device >= sm80 not available")
+    qtype = qint4
+    group_size = 128
+    dtype = torch.bfloat16
+    inputs = torch.rand((batch_size,) + (tokens, embeddings), dtype=dtype, device=device)
+    # Create a TinyGemmWeightQBitsTensor from a QBitsTensor
+    qbt = random_qweight((tokens, embeddings), qtype, dtype, group_size=group_size, device=device)
+    tinygemm_qweight = TinyGemmWeightQBitsTensor(
+        qtype=qbt.qtype,
+        axis=qbt.axis,
+        group_size=qbt._group_size,
+        size=qbt.size(),
+        stride=qbt.stride(),
+        data=qbt._data.unpack(),
+        scale_shift=(qbt._scale, qbt._shift),
+    )
+    bias = random_tensor((tokens,), dtype=dtype).to(device) if use_bias else None
+    qout = torch.nn.functional.linear(inputs, tinygemm_qweight, bias)
+    out = torch.nn.functional.linear(inputs, qbt.dequantize(), bias)
+    assert_similar(out, qout)

--- a/test/tensor/weights/optimized/test_tinygemm_weight_qbits_tensor.py
+++ b/test/tensor/weights/optimized/test_tinygemm_weight_qbits_tensor.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from helpers import assert_similar, device_eq, random_weight_qbits_tensor
+from helpers import assert_similar, device_eq, random_qweight
 from packaging import version
 
 from optimum.quanto import qint4
@@ -35,7 +35,7 @@ def test_tinygemm_weight_qbits_tensor_from_qbits_tensor(in_features, out_feature
     group_size = 128
     dtype = torch.bfloat16
     shape = (out_features, in_features)
-    qbt = random_weight_qbits_tensor(shape, qtype, dtype, group_size, device)
+    qbt = random_qweight(shape, qtype, dtype, group_size=group_size, device=device)
     # Create a TinyGemmWeightQBitsTensor from the WeightQBitsTensor members
     tgqbt = TinyGemmWeightQBitsTensor(
         qtype=qbt.qtype,
@@ -72,7 +72,7 @@ def test_tinygemm_weight_qbits_tensor_move(device):
     dtype = torch.bfloat16
     shape = (1024, 1024)
     # Create a TinyGemmWeightQBitsTensor from a QBitsTensor on CPU
-    qbt = random_weight_qbits_tensor(shape, qtype, dtype, group_size, device=torch.device("cpu"))
+    qbt = random_qweight(shape, qtype, dtype, group_size=group_size, device=torch.device("cpu"))
     tgqbt_cpu = TinyGemmWeightQBitsTensor(
         qtype=qbt.qtype,
         axis=qbt.axis,


### PR DESCRIPTION
# What does this PR do?

This makes sure QTensor linear operations using optimized kernels are giving the same results as those using dequantized weights.  