### PR TITLE
fix: use reshape instead of view

### DIFF
--- a/optimum/quanto/library/extensions/cuda/__init__.py
+++ b/optimum/quanto/library/extensions/cuda/__init__.py
@@ -188,9 +188,9 @@ def gemm_f16i4_marlin(
         device=input.device,
     )
     ext.lib.marlin_gemm_f16i4(
-        input.view((-1, input.shape[-1])),
+        input.reshape((-1, input.shape[-1])),
         other,
-        output.view((-1, output.shape[-1])),
+        output.reshape((-1, output.shape[-1])),
         scales,
         zeropoint,
         workspace,

--- a/optimum/quanto/library/qbytes_mm.py
+++ b/optimum/quanto/library/qbytes_mm.py
@@ -42,8 +42,8 @@ def qbytes_int_mm(activations: torch.Tensor, weights: torch.Tensor, output_scale
         out_data = torch._int_mm(activations, weights)
     else:
         output_shape = activations.shape[:-1] + (out_features,)
-        out_data = torch._int_mm(activations.view(-1, in_features), weights)
-        out_data = out_data.view(output_shape)
+        out_data = torch._int_mm(activations.reshape(-1, in_features), weights)
+        out_data = out_data.reshape(output_shape)
     # We must evaluate the output as float32 because the multiplication
     # of the int32 data by the scales might overflow
     fp32_output = out_data.to(torch.float32) * output_scales.t()
@@ -59,8 +59,8 @@ def qbytes_int8pack_mm(activations: torch.Tensor, weights: torch.Tensor, output_
         in_features = activations.shape[-1]
         out_features = weights.shape[0]
         output_shape = activations.shape[:-1] + (out_features,)
-        out_data = torch._weight_int8pack_mm(activations.view(-1, in_features), weights, output_scales)
-        return out_data.view(output_shape)
+        out_data = torch._weight_int8pack_mm(activations.reshape(-1, in_features), weights, output_scales)
+        return out_data.reshape(output_shape)
 
 
 @torch.library.impl("quanto::qbytes_mm", "default")

--- a/optimum/quanto/library/qbytes_mm.py
+++ b/optimum/quanto/library/qbytes_mm.py
@@ -92,7 +92,7 @@ def qbytes_mm_impl_cuda(activations: torch.Tensor, weights: torch.Tensor, output
 def qbytes_mm_impl_cpu(activations: torch.Tensor, weights: torch.Tensor, output_scales: torch.Tensor) -> torch.Tensor:
     if (
         # FIXME: accuracy issues with 2.4.x
-        version.parse(torch.__version__).release > version.parse("2.4.1").release
+        version.parse(torch.__version__).release > version.parse("2.5.0").release
         and activations.dtype == torch.int8
         and weights.dtype == torch.int8
     ):

--- a/optimum/quanto/nn/qlayernorm.py
+++ b/optimum/quanto/nn/qlayernorm.py
@@ -36,12 +36,13 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
     ):
         if activations is None:
             return None
+        dtype = None if module.weight is None else module.weight.dtype
         return cls(
             module.normalized_shape,
             module.eps,
             module.elementwise_affine,
             module.bias is not None,
-            dtype=module.weight.dtype,
+            dtype=dtype,
             device=device,
             weights=None,  # We never quantize QLayerNorm weights
             activations=activations,

--- a/optimum/quanto/nn/qmodule.py
+++ b/optimum/quanto/nn/qmodule.py
@@ -136,8 +136,9 @@ class QModuleMixin(ABC):
         if optimizer is None and self.weight_qtype is not None:
             optimizer = AbsmaxOptimizer() if self.weight_qtype.bits == 8 else MaxOptimizer()
         self.optimizer = optimizer
-        self.register_buffer("input_scale", torch.ones((), dtype=self.weight.dtype, device=device))
-        self.register_buffer("output_scale", torch.ones((), dtype=self.weight.dtype, device=device))
+        scale_dtype = torch.float32 if self.weight is None else self.weight.dtype
+        self.register_buffer("input_scale", torch.ones((), dtype=scale_dtype, device=device))
+        self.register_buffer("output_scale", torch.ones((), dtype=scale_dtype, device=device))
 
     def disable_output_quantization(self):
         if "output" in self._quantize_hooks:

--- a/optimum/quanto/tensor/weights/awq/packed.py
+++ b/optimum/quanto/tensor/weights/awq/packed.py
@@ -68,9 +68,9 @@ def reverse_awq_order(t: torch.Tensor):
         dtype=torch.int32,
         device=t.device,
     )
-    reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
+    reverse_order_tensor = reverse_order_tensor.reshape(-1, 32 // bits)
     reverse_order_tensor = reverse_order_tensor[:, AWQ_REVERSE_ORDER]
-    reverse_order_tensor = reverse_order_tensor.view(-1)
+    reverse_order_tensor = reverse_order_tensor.reshape(-1)
 
     t = t[:, reverse_order_tensor]
 

--- a/optimum/quanto/tensor/weights/marlin/fp8/qbits.py
+++ b/optimum/quanto/tensor/weights/marlin/fp8/qbits.py
@@ -32,7 +32,7 @@ class MarlinF8QBytesLinearFunction(QuantizedLinearFunction):
         input_shape = input.shape
 
         if input.ndim > 2:
-            input = input.view(-1, input_shape[-1])
+            input = input.reshape(-1, input_shape[-1])
 
         output = torch.ops.quanto.gemm_f16f8_marlin(
             input,

--- a/optimum/quanto/tensor/weights/packing.py
+++ b/optimum/quanto/tensor/weights/packing.py
@@ -34,7 +34,7 @@ def unpack_int32_to_uint8(packed: torch.Tensor, bits: int):
     unpacked = torch.bitwise_right_shift(packed[:, :, None], shifts[None, None, :]).to(
         torch.int8  # smallest dtype available
     )
-    unpacked = unpacked.view(unpacked.shape[0], -1)
+    unpacked = unpacked.reshape(unpacked.shape[0], -1)
 
     # Convert to unsigned
     unpacked = torch.bitwise_and(unpacked, (2**bits) - 1)

--- a/optimum/quanto/tensor/weights/qbytes.py
+++ b/optimum/quanto/tensor/weights/qbytes.py
@@ -74,8 +74,8 @@ class WeightQBytesLinearFunction(QuantizedLinearFunction):
             in_features = input.shape[-1]
             out_features = other.shape[0]
             output_shape = input.shape[:-1] + (out_features,)
-            output = torch.ops.quanto.qbytes_mm(input.view(-1, in_features), other._data, other._scale)
-            output = output.view(output_shape)
+            output = torch.ops.quanto.qbytes_mm(input.reshape(-1, in_features), other._data, other._scale)
+            output = output.reshape(output_shape)
         if bias is not None:
             output = output + bias
         return output

--- a/optimum/quanto/tensor/weights/tinygemm/qbits.py
+++ b/optimum/quanto/tensor/weights/tinygemm/qbits.py
@@ -49,9 +49,9 @@ class TinyGemmQBitsLinearFunction(QuantizedLinearFunction):
         out_features = other.shape[0]
         output_shape = input.shape[:-1] + (out_features,)
         output = torch._weight_int4pack_mm(
-            input.view(-1, in_features), other._data._data, other._group_size, other._scale_shift
+            input.reshape(-1, in_features), other._data._data, other._group_size, other._scale_shift
         )
-        output = output.view(output_shape)
+        output = output.reshape(output_shape)
         if bias is not None:
             output = output + bias
         return output

--- a/test/tensor/activations/test_activations_compile.py
+++ b/test/tensor/activations/test_activations_compile.py
@@ -27,7 +27,7 @@ def compile_for_device(f, device):
     return torch.compile(f, backend=backend)
 
 
-@torch_min_version("2.5.0")
+@torch_min_version("2.6.0")
 @pytest.mark.parametrize("input_shape", [(2, 10), (10, 32, 32)])
 @pytest.mark.parametrize("qtype", [qint8], ids=["qint8"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"])


### PR DESCRIPTION
Most of the time, we want the resulting Tensor to be contiguous, so it is better to use reshape to enforce it.

Fixes #327 
