### PR TITLE
fix(library): Propagate upstream Marlin kernel fix

### DIFF
--- a/test/tensor/weights/optimized/test_marlin_int4_weight_qbits_tensor.py
+++ b/test/tensor/weights/optimized/test_marlin_int4_weight_qbits_tensor.py
@@ -131,7 +131,7 @@ def test_marlin_int4_weight_qbits_tensor_linear(batch_size, tokens, in_features,
     )
 
 
-#Tests previous Marlin kernel bug: https://github.com/huggingface/optimum-quanto/issues/332
+# Tests previous Marlin kernel bug: https://github.com/huggingface/optimum-quanto/issues/332
 @pytest.mark.skipif(
     not is_extension_available("quanto_cuda") or torch.cuda.get_device_capability()[0] < 8,
     reason="CUDA >= sm80 not available",

--- a/test/tensor/weights/optimized/test_marlin_int4_weight_qbits_tensor.py
+++ b/test/tensor/weights/optimized/test_marlin_int4_weight_qbits_tensor.py
@@ -131,15 +131,14 @@ def test_marlin_int4_weight_qbits_tensor_linear(batch_size, tokens, in_features,
     )
 
 
-@pytest.mark.xfail(reason="Bug in Marlin kernel", strict=False)
+#Tests previous Marlin kernel bug: https://github.com/huggingface/optimum-quanto/issues/332
 @pytest.mark.skipif(
     not is_extension_available("quanto_cuda") or torch.cuda.get_device_capability()[0] < 8,
     reason="CUDA >= sm80 not available",
 )
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("tokens", [48, 64])
-# @pytest.mark.parametrize("in_features", [1024, 2048, 4096, 16384])
-@pytest.mark.parametrize("in_features", [4096, 16384])
+@pytest.mark.parametrize("in_features", [1024, 2048, 4096, 16384])
 @pytest.mark.parametrize("out_features", [2048, 4096])
 def test_marlin_int4_weight_qbits_tensor_linear_failing(batch_size, tokens, in_features, out_features):
     dtype = torch.float16


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/optimum-quanto/issues/332

TLDR; There was a data race bug in the Marlin kernel. This fix basically adds a separate shared memory region for the final reduction tree. Unfortunately, this affects the minimum hardware requirements for the kernel, it won't work on GPUs with compute capability < 8.0.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/optimum-quanto/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you run all tests locally and make sure they pass.
- [ ] Did you write any new necessary tests?