### PR TITLE
Fix error when trying to access `state_dict` after activation quantization

### DIFF
--- a/optimum/quanto/nn/qmodule.py
+++ b/optimum/quanto/nn/qmodule.py
@@ -147,7 +147,9 @@ class QModuleMixin(ABC):
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         if self.weight_qtype is None or not self.frozen:
             # Save standard weight Tensor
-            destination[prefix + "weight"] = self.weight if keep_vars else self.weight.detach()
+            destination[prefix + "weight"] = (
+                self.weight if (self.weight is None or keep_vars) else self.weight.detach()
+            )
         else:
             # Save QTensor using dedicated method
             self.weight.save_to_state_dict(destination, prefix + "weight.", keep_vars)


### PR DESCRIPTION
# What does this PR do?
Trying to access the model state dict after using activation quantization throws an unexpected error. 

```
Traceback (most recent call last):
  File "/home/dhruv/diffusers/../scripts/create_dummy_flux.py", line 42, in <module>
    model.state_dict()
  File "/home/dhruv/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2219, in state_dict
    module.state_dict(
  File "/home/dhruv/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2219, in state_dict
    module.state_dict(
  File "/home/dhruv/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2219, in state_dict
    module.state_dict(
  [Previous line repeated 1 more time]
  File "/home/dhruv/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2216, in state_dict
    self._save_to_state_dict(destination, prefix, keep_vars)
  File "/home/dhruv/miniconda3/envs/diffusers/lib/python3.10/site-packages/optimum/quanto/nn/qmodule.py", line 150, in _save_to_state_dict
    destination[prefix + "weight"] = self.weight if keep_vars else self.weight.detach()
AttributeError: 'NoneType' object has no attribute 'detach'
```

This is because when replacing the LayerNorms in the model with QLayerNorm the weights are set to `None`, so this line will throw an error 
https://github.com/huggingface/optimum-quanto/blob/2202f84eff25a1f7204cb82109563831faf18e49/optimum/quanto/nn/qmodule.py#L150   

Snippet to test 
```python
import torch
from diffusers import FluxTransformer2DModel
from optimum.quanto import freeze, quantize, qint8, Calibration

torch_device = torch.device("cuda")


def get_dummy_inputs():
    return {
        "hidden_states": torch.randn(
            (1, 4096, 64), generator=torch.Generator("cpu").manual_seed(0)
        ).to(torch_device, torch.bfloat16),
        "encoder_hidden_states": torch.randn(
            (1, 512, 4096),
            generator=torch.Generator("cpu").manual_seed(0),
        ).to(torch_device, torch.bfloat16),
        "pooled_projections": torch.randn(
            (1, 768),
            generator=torch.Generator("cpu").manual_seed(0),
        ).to(torch_device, torch.bfloat16),
        "timestep": torch.tensor([1]).to(torch_device, torch.bfloat16),
        "img_ids": torch.randn(
            (4096, 3), generator=torch.Generator("cpu").manual_seed(0)
        ).to(torch_device, torch.bfloat16),
        "txt_ids": torch.randn(
            (512, 3), generator=torch.Generator("cpu").manual_seed(0)
        ).to(torch_device, torch.bfloat16),
        "guidance": torch.tensor([3.5]).to(torch_device, torch.bfloat16),
    }


model = FluxTransformer2DModel.from_pretrained(
    "hf-internal-testing/tiny-flux-transformer"
)
quantize(model, weights=qint8, activations=qint8)
model.to(torch_device)

with Calibration(momentum=0.9):
    model(**get_dummy_inputs())

freeze(model)
model.state_dict()
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/optimum-quanto/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you run all tests locally and make sure they pass.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
