### PR TITLE
Bump minimal pytorch version to 2.6

### DIFF
--- a/.github/workflows/linux-cuda-tests.yml
+++ b/.github/workflows/linux-cuda-tests.yml
@@ -22,14 +22,14 @@ jobs:
     uses: ./.github/workflows/python-quality.yml
   test-ubuntu-cuda:
     needs: [check-commits, python-quality]
-    runs-on: 
+    runs-on:
       group: aws-g5-4xlarge-plus
     strategy:
       fail-fast: false
       matrix:
-        cuda-version: ["11.8", "12.1", "12.4"]
+        cuda-version: ["11.8", "12.4", "12.6"]
     container:
-      image: pytorch/pytorch:2.4.0-cuda${{ matrix.cuda-version }}-cudnn9-devel
+      image: pytorch/pytorch:2.6.0-cuda${{ matrix.cuda-version }}-cudnn9-devel
       options: --gpus 0
 
     steps:

--- a/.github/workflows/linux-examples.yml
+++ b/.github/workflows/linux-examples.yml
@@ -22,14 +22,14 @@ jobs:
     uses: ./.github/workflows/python-quality.yml
   run-examples:
     needs: [check-commits, python-quality]
-    runs-on: 
+    runs-on:
       group: aws-g5-4xlarge-plus
     strategy:
       fail-fast: false
       matrix:
         device: ["cpu", "cuda"]
     container:
-      image: pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel
+      image: pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel
       options: --gpus 0
 
     steps:

--- a/optimum/quanto/__init__.py
+++ b/optimum/quanto/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.6dev"
+__version__ = "0.2.7dev"
 
 from .calibrate import *
 from .library import *

--- a/optimum/quanto/library/extensions/mps/README.md
+++ b/optimum/quanto/library/extensions/mps/README.md
@@ -5,3 +5,5 @@ To add a new implementation for an operation defined in `library./ops.py`:
 - add the corresponding `.mm` file to the list of sources in `__init__.py`,
 - add a binding to `pybind_module.cpp`,
 - provide an implementation calling the binding in `__init__.py`.
+
+Note: torch JIT extensions for MPS requires the xcode command-line tools.

--- a/optimum/quanto/tensor/weights/tinygemm/qbits.py
+++ b/optimum/quanto/tensor/weights/tinygemm/qbits.py
@@ -48,9 +48,14 @@ class TinyGemmQBitsLinearFunction(QuantizedLinearFunction):
         in_features = input.shape[-1]
         out_features = other.shape[0]
         output_shape = input.shape[:-1] + (out_features,)
-        output = torch._weight_int4pack_mm(
-            input.reshape(-1, in_features), other._data._data, other._group_size, other._scale_shift
-        )
+        if input.device.type == "cpu":
+            output = torch._weight_int4pack_mm_for_cpu(
+                input.reshape(-1, in_features), other._data._data, other._group_size, other._scale_shift
+            )
+        else:
+            output = torch._weight_int4pack_mm(
+                input.reshape(-1, in_features), other._data._data, other._group_size, other._scale_shift
+            )
         output = output.reshape(output_shape)
         if bias is not None:
             output = output + bias

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [{ name = 'David Corvoysier' }]
 maintainers = [
     {name = "HuggingFace Inc. Special Ops Team", email="hardware@huggingface.co"},
 ]
-dependencies = ['torch>=2.4.0', 'ninja', 'numpy', 'safetensors', 'huggingface_hub']
+dependencies = ['torch>=2.6.0', 'ninja', 'numpy', 'safetensors', 'huggingface_hub']
 license = { text = 'Apache-2.0' }
 readme = 'README.md'
 dynamic = ['version']

--- a/test/tensor/activations/test_activations_compile.py
+++ b/test/tensor/activations/test_activations_compile.py
@@ -27,7 +27,7 @@ def compile_for_device(f, device):
     return torch.compile(f, backend=backend)
 
 
-@torch_min_version("2.6.0")
+@torch_min_version("2.7.0")
 @pytest.mark.parametrize("input_shape", [(2, 10), (10, 32, 32)])
 @pytest.mark.parametrize("qtype", [qint8], ids=["qint8"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"])
@@ -48,7 +48,6 @@ def test_compile_quantize_tensor(input_shape, qtype, dtype, device):
     assert qa.axis is None
 
 
-@torch_min_version("2.3.0")
 def test_compile_qtensor_to(device):
     input_shape = (10, 32, 32)
     a = random_tensor(input_shape).to(device)

--- a/test/tensor/test_packed_tensor.py
+++ b/test/tensor/test_packed_tensor.py
@@ -44,7 +44,7 @@ def test_packed_tensor_serialization(bits, device):
     b = io.BytesIO()
     torch.save(packed, b)
     b.seek(0)
-    packed_reloaded = torch.load(b)
+    packed_reloaded = torch.load(b, weights_only=False)
     assert isinstance(packed_reloaded, PackedTensor)
     assert packed_reloaded.shape == packed.shape
     assert packed_reloaded.dtype == packed.dtype

--- a/test/tensor/weights/test_weight_qbits_tensor.py
+++ b/test/tensor/weights/test_weight_qbits_tensor.py
@@ -28,7 +28,7 @@ def test_weight_qbits_tensor_serialization(qtype, axis):
     b = io.BytesIO()
     torch.save(qa, b)
     b.seek(0)
-    qa_reloaded = torch.load(b)
+    qa_reloaded = torch.load(b, weights_only=False)
     assert isinstance(qa_reloaded, WeightQBitsTensor)
     assert qa_reloaded.qtype == qa.qtype
     assert qa_reloaded.dtype == qa.dtype

--- a/test/tensor/weights/test_weight_qbytes_tensor_serialization.py
+++ b/test/tensor/weights/test_weight_qbytes_tensor_serialization.py
@@ -30,7 +30,7 @@ def test_weights_qbytes_tensor_serialization(input_shape, qtype, dtype, axis):
     b = io.BytesIO()
     torch.save(qinputs, b)
     b.seek(0)
-    qinputs_reloaded = torch.load(b)
+    qinputs_reloaded = torch.load(b, weights_only=False)
     assert qinputs_reloaded.qtype == qtype
     assert torch.equal(qinputs_reloaded._scale, qinputs._scale)
     if qtype.is_floating_point:


### PR DESCRIPTION
# What does this PR do?

There were some changes in the `pytorch` "internal" API that are incompatible between `2.5` and `2.6`. This bumps the minimum version and adapts to the new API.