### PR TITLE
test: disable activations compilation test

### DIFF
--- a/tests/tensor/activations/test_activations_compile.py
+++ b/tests/tensor/activations/test_activations_compile.py
@@ -14,7 +14,7 @@
 
 import pytest
 import torch
-from helpers import random_tensor, torch_min_version
+from helpers import random_tensor
 
 from optimum.quanto import ActivationQBytesTensor, absmax_scale, qint8, quantize_activation
 

--- a/tests/tensor/activations/test_activations_compile.py
+++ b/tests/tensor/activations/test_activations_compile.py
@@ -27,7 +27,7 @@ def compile_for_device(f, device):
     return torch.compile(f, backend=backend)
 
 
-@torch_min_version("2.7.0")
+@pytest.mark.skip("Disabled as it is not working (yet ?)")
 @pytest.mark.parametrize("input_shape", [(2, 10), (10, 32, 32)])
 @pytest.mark.parametrize("qtype", [qint8], ids=["qint8"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"])


### PR DESCRIPTION
# What does this PR do?

After the release of pytorch 2.7, the compilation of graphs including dynamically quantized tensors is still not working.
The implementation should be reworked as the creation of tensor subclasses inside a graph should be supported since 2.6.