### PR TITLE
check shift before using awq linear on XPU

### DIFF
--- a/optimum/quanto/tensor/weights/qbits.py
+++ b/optimum/quanto/tensor/weights/qbits.py
@@ -110,6 +110,7 @@ class WeightQBitsTensor(QBitsTensor):
             and group_size == 128
             and len(size) == 2
             and data.device.type == "xpu"
+            and shift.dtype == torch.int8
             and version.parse(torch.__version__).release >= version.parse("2.8.0").release
         ):
             if type(data) is PackedTensor:


### PR DESCRIPTION
Hi @SunMarc . This commit should be included in #395 . Sorry for I forgot to push this commit. The shift is required to be int8 for awq linear in XPU. Please review it. Thanks!