### PR TITLE
Fix import due to optimum v2

### DIFF
--- a/optimum/quanto/subpackage/commands/base.py
+++ b/optimum/quanto/subpackage/commands/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from optimum.commands import BaseOptimumCLICommand, CommandInfo
+from optimum.commands.base import BaseOptimumCLICommand, CommandInfo
 from optimum.commands.optimum_cli import optimum_cli_subcommand
 
 from .quantize import QuantizeCommand

--- a/optimum/quanto/subpackage/commands/quantize.py
+++ b/optimum/quanto/subpackage/commands/quantize.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from optimum.commands import BaseOptimumCLICommand
+from optimum.commands.base import BaseOptimumCLICommand
 from optimum.exporters import TasksManager
 
 from ...models import QuantizedTransformersModel


### PR DESCRIPTION
# What does this PR do?

This PR fixes the following issue: 

> We have moved to native namespace packages in optimum v2 to allow a better dev experience (optimum and its subpackages like optimum-onnx can now be in editable mode in the same env)
> Basically the constraint is that we can't have init.py files in namespaces, for example optimum.commands is a namespace in optimum.
> 
> To fix this, direct imports from namespaces should be removed (from optimum.commands import BaseOptimumCLICommand -> from optimum.commands.base import BaseOptimumCLICommand)