### PR TITLE
Fix noise generation issue with qfloat8_e4m3fn quantization

### DIFF
--- a/optimum/quanto/tensor/weights/qbytes.py
+++ b/optimum/quanto/tensor/weights/qbytes.py
@@ -126,7 +126,7 @@ class WeightQBytesTensor(QBytesTensor):
             and len(size) == 2
             and (data.device.type == "cuda" and torch.version.cuda)
             and axis == 0
-            and torch.cuda.get_device_capability(data.device)[0] >= 8
+            and torch.cuda.get_device_capability(data.device)[0] >= 20
             and is_extension_available("quanto_cuda")
         ):
             out_features, in_features = size


### PR DESCRIPTION
## Problem

When using `qfloat8_e4m3fn` quantization, the generated output is noise instead of the expected image. This issue is caused by `MarlinF8QBytesTensor`.

## Root Cause

The Marlin kernel appears to have issues when tensor sizes increase (possibly overflow or buffer overlap in intermediate results).

## Solution

Disable the Marlin kernel path by raising the CUDA compute capability requirement from 8 to 20. This effectively falls back to the standard `WeightQBytesTensor` implementation which produces correct results.

This fix also applies to version 0.2.6.

## Changes

- `optimum/quanto/tensor/weights/qbytes.py`: Changed `torch.cuda.get_device_capability(data.device)[0] >= 8` to `>= 20`
