### PR TITLE
docs: update maintenance references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ unsure, it is always a good idea to open an issue to get some feedback.
 
 You will need basic `git` proficiency to contribute. While `git` is not the easiest tool to use, it has the greatest manual. Type `git --help` in a shell and enjoy! If you prefer books, [Pro Git](https://git-scm.com/book/en/v2) is a very good reference.
 
-You'll need **Python 3.8** or above to contribute. Follow the steps below to start contributing:
+You'll need **Python 3.9** or above to contribute. Follow the steps below to start contributing:
 
 1. Fork the [repository](https://github.com/huggingface/optimum-quanto) by
    clicking on the **[Fork](https://github.com/huggingface/optimum-quanto/fork)** button on the repository's page. This creates a copy of the code
@@ -136,7 +136,7 @@ You'll need **Python 3.8** or above to contribute. Follow the steps below to sta
    pytest tests/<TEST_TO_RUN>.py
    ```
 
-   `optimum-quanto` relies on `black` and `ruff` to format its source code
+   `optimum-quanto` relies on `ruff` to format its source code
    consistently. After you make changes, apply automatic style corrections and code verifications
    that can't be automated in one go with:
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ with torch.device('meta'):
 requantize(new_model, state_dict, quantization_map, device=torch.device('cuda'))
 ```
 
-Please refer to the [examples](https://github.com/huggingface/quanto/tree/main/examples) for instantiations of that workflow.
+Please refer to the [examples](https://github.com/huggingface/optimum-quanto/tree/main/examples) for instantiations of that workflow.
 
 
 ## Design overview

--- a/bench/generation/README.md
+++ b/bench/generation/README.md
@@ -16,21 +16,21 @@ The paragraphs below display results for some popular models on a NVIDIA A10 GPU
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/meta-llama-Meta-Llama-3.1-8B_bf16_Accuracy.png" alt="meta-llama/Meta-llama-3.1-8B Lambada prediction accuracy">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/meta-llama-Meta-Llama-3.1-8B_bf16_Accuracy.png" alt="meta-llama/Meta-llama-3.1-8B Lambada prediction accuracy">
   </div>
  </center>
 </div>
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/meta-llama-Meta-Llama-3.1-8B_bf16_Perplexity.png" alt="meta-llama/Meta-Llama-3.1-8B WikiText perplexity">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/meta-llama-Meta-Llama-3.1-8B_bf16_Perplexity.png" alt="meta-llama/Meta-Llama-3.1-8B WikiText perplexity">
   </div>
  </center>
 </div>
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/meta-llama-Meta-Llama-3.1-8B_bf16_Latency__ms_.png" alt="meta-llama/Meta-Llama-3.1-8B Latency">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/meta-llama-Meta-Llama-3.1-8B_bf16_Latency__ms_.png" alt="meta-llama/Meta-Llama-3.1-8B Latency">
   </div>
  </center>
 </div>
@@ -39,21 +39,21 @@ The paragraphs below display results for some popular models on a NVIDIA A10 GPU
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/mistralai-Mistral-7B-Instruct-v0.3_bf16_Accuracy.png" alt="mistralai/Mistral-7B-Instruct-v0.3 Lambada prediction accuracy">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/mistralai-Mistral-7B-Instruct-v0.3_bf16_Accuracy.png" alt="mistralai/Mistral-7B-Instruct-v0.3 Lambada prediction accuracy">
   </div>
  </center>
 </div>
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/mistralai-Mistral-7B-Instruct-v0.3_bf16_Perplexity.png" alt="mistralai/Mistral-7B-Instruct-v0.3 WikiText perplexity">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/mistralai-Mistral-7B-Instruct-v0.3_bf16_Perplexity.png" alt="mistralai/Mistral-7B-Instruct-v0.3 WikiText perplexity">
   </div>
  </center>
 </div>
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/mistralai-Mistral-7B-Instruct-v0.3_bf16_Latency__ms_.png" alt="mistralai/Mistral-7B-Instruct-v0.3 Latency">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/mistralai-Mistral-7B-Instruct-v0.3_bf16_Latency__ms_.png" alt="mistralai/Mistral-7B-Instruct-v0.3 Latency">
   </div>
  </center>
 </div>
@@ -62,21 +62,21 @@ The paragraphs below display results for some popular models on a NVIDIA A10 GPU
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/google-gemma-2b_bf16_Accuracy.png" alt="google-gemma-2b Lambada prediction accuracy">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/google-gemma-2b_bf16_Accuracy.png" alt="google-gemma-2b Lambada prediction accuracy">
   </div>
  </center>
 </div>
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/google-gemma-2b_bf16_Perplexity.png" alt="google-gemma-2b WikiText perplexity">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/google-gemma-2b_bf16_Perplexity.png" alt="google-gemma-2b WikiText perplexity">
   </div>
  </center>
 </div>
 
 <div class="row"><center>
   <div class="column">
-    <img src="https://github.com/huggingface/quanto/blob/main/bench/generation/charts/google-gemma-2b_bf16_Latency__ms_.png" alt="google-gemma-2b Latency">
+    <img src="https://github.com/huggingface/optimum-quanto/blob/main/bench/generation/charts/google-gemma-2b_bf16_Latency__ms_.png" alt="google-gemma-2b Latency">
   </div>
  </center>
 </div>

--- a/examples/vision/StableDiffusion/README.md
+++ b/examples/vision/StableDiffusion/README.md
@@ -10,8 +10,8 @@ Before running the scripts, make sure to install the library's training dependen
 
 To make sure you can successfully run the latest versions of the example scripts, we highly recommend **installing from source** and keeping the install up to date as we update the example scripts frequently and install some example-specific requirements. To do this, execute the following steps in a new virtual environment:
 ```bash
-git clone https://github.com/huggingface/quanto
-cd quanto
+git clone https://github.com/huggingface/optimum-quanto
+cd optimum-quanto
 pip install -e .
 ```
 


### PR DESCRIPTION
The documentation still contains a few references from before the repository was renamed. In particular, the Stable Diffusion setup clones `huggingface/quanto` and then enters `quanto`, while a fresh clone of the current repository is named `optimum-quanto`.

This updates the repository links and clone instructions, including benchmark image sources. It also aligns the contributing guide with the current `requires-python = ">=3.9.0"` metadata and the Ruff-only Makefile commands.

Validation:
- all newly referenced GitHub URLs return HTTP 200
- no `github.com/huggingface/quanto` references remain in Markdown files
- `git diff --check` passes

No runtime code is changed, so the model test suite was not run.