### PR TITLE
Fix activation-only weights and split metadata

### DIFF
--- a/optimum/quanto/nn/qmodule.py
+++ b/optimum/quanto/nn/qmodule.py
@@ -254,7 +254,7 @@ class QModuleMixin(ABC):
         """
         if self.weight_qtype is None:
             # QModule that does not quantize its weights
-            return None
+            return self.weight
         if isinstance(self.weight, QTensor):
             # Frozen QModule
             return self.weight
@@ -303,7 +303,7 @@ class QModuleMixin(ABC):
 
     def freeze(self):
         qweight = self.qweight
-        if qweight is not None:
+        if qweight is not self.weight:
             # Replace float weights by quantized weights
             self.weight = torch.nn.Parameter(qweight)
 

--- a/optimum/quanto/tensor/activations/qbytes_ops.py
+++ b/optimum/quanto/tensor/activations/qbytes_ops.py
@@ -239,7 +239,7 @@ def split(op, input, *args, **kwargs):
         return qfallback(op, input, *args, **kwargs)
     out_datas = op(input._data, *args, **kwargs)
     return [
-        ActivationQBytesTensor(input.qtype, input.size(), input.stride(), out_data, input._scale)
+        ActivationQBytesTensor(input.qtype, out_data.size(), out_data.stride(), out_data, input._scale)
         for out_data in out_datas
     ]
 

--- a/tests/quantize/test_quantize_mlp.py
+++ b/tests/quantize/test_quantize_mlp.py
@@ -93,6 +93,26 @@ def test_quantize_mlp_weights_only_float8(weights, frozen, device):
     _test_quantize_mlp(weights, None, None, frozen, device)
 
 
+@pytest.mark.skip_device("mps")
+def test_quantize_mlp_activations_only(device):
+    _test_quantize_mlp(None, qint8, None, False, device, atol=1e-3)
+
+
+@pytest.mark.skip_device("mps")
+def test_quantize_activations_only_preserves_tied_weights(device):
+    model = torch.nn.Module()
+    model.embedding = torch.nn.Embedding(10, 4, device=device)
+    model.lm_head = torch.nn.Linear(4, 10, bias=False, device=device)
+    model.lm_head.weight = model.embedding.weight
+
+    quantize(model, weights=None, activations=qint8)
+    freeze(model)
+
+    assert model.embedding.weight is model.lm_head.weight
+    output = model.lm_head(model.embedding(torch.tensor([0], device=device)))
+    assert isinstance(output, ActivationQBytesTensor)
+
+
 @pytest.mark.parametrize("weights", [qint8], ids=["w-qint8"])
 @pytest.mark.parametrize("frozen", [True, False], ids=["frozen", "non-frozen"])
 @pytest.mark.skip_device("mps")

--- a/tests/tensor/activations/test_activations_dispatch.py
+++ b/tests/tensor/activations/test_activations_dispatch.py
@@ -72,6 +72,18 @@ def test_qactivation_cat(input_shape, device):
     assert_similar(torch.cat([qinputs.dequantize(), qother.dequantize()]), qcat)
 
 
+def test_qactivation_split(device):
+    qinputs = random_qactivation((10, 3), dtype=torch.float32).to(device)
+    parts = torch.split(qinputs, 4)
+    expected_parts = torch.split(qinputs.dequantize(), 4)
+    for part, expected in zip(parts, expected_parts):
+        assert isinstance(part, ActivationQBytesTensor)
+        assert part.shape == part._data.shape == expected.shape
+        assert part.stride() == part._data.stride()
+        assert torch.equal(part._scale, qinputs._scale)
+        assert torch.equal(part.dequantize(), expected)
+
+
 def test_qactivation_transpose_2d(device):
     input_shape = (4, 6)
     qinputs = random_qactivation(input_shape).to(device)


### PR DESCRIPTION
# What does this PR do?

This PR fixes two issues in activation quantization and quantized tensor operations:

- Activation-only quantization previously returned `None` from `QModuleMixin.qweight` when `weights=None`, causing modules such as `QLinear` to fail during forward execution.
  - The original floating-point weight is now returned when weight quantization is disabled.
  - `freeze()` avoids recreating an unchanged weight parameter, preserving tied weights such as `embedding.weight is lm_head.weight`.

- `ActivationQBytesTensor.split()` previously constructed every output with the input tensor's shape and stride.
  - Each split tensor now uses its own data shape and stride.
  - The quantization type and scale metadata remain unchanged.
  - The dequantized output matches splitting the dequantized input.

Regression tests were added for activation-only inference, tied weights, and split tensor metadata.

## Test plan

- `pytest tests/tensor/activations/test_activations_dispatch.py -q`
  - 56 passed
- Activation-only, tied-weight, and existing int8 activation tests
  - 4 passed, 4 MPS-only cases skipped
- Existing dynamic and frozen qint8 weight tests
  - 4 passed
- Ruff checks passed
- `git diff --check` passed

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/optimum-quanto/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Not applicable — these are focused bug fixes discovered during code review and were not associated with an existing issue or forum discussion.
- [ ] Did you run all tests locally and make sure they pass?
  - The relevant test suites passed; the complete repository test suite was not run locally.64 passed; 4 MPS-only cases skipped.
- [x] Did you write any new necessary tests?